### PR TITLE
Generate SQL dialect BNF/EBNF reports

### DIFF
--- a/references/sql_dialects/firebird_psql_ebnf.md
+++ b/references/sql_dialects/firebird_psql_ebnf.md
@@ -1,0 +1,208 @@
+### Firebird SQL and PSQL — EBNF Report
+
+Version scope: Firebird 3.0–5.0 features. Focus on SQL DML/DDL, PSQL (procedural SQL) blocks, exceptions, and triggers.
+
+EBNF index:
+- Tokens and lexical specifics
+- Expressions and operators
+- Queries (SELECT, set ops, CTE, windowing)
+- DML (INSERT/UPDATE/DELETE/MERGE) with RETURNING
+- DDL (domains, tables, generators/sequences, collations, computed columns)
+- PSQL blocks (BEGIN..END), variables, cursors, exceptions
+- Triggers, procedures, functions
+- Utilities (SET, GRANT/REVOKE, COMMENT)
+
+Tokens and lexical specifics
+```ebnf
+identifier           ::= unquoted_identifier | quoted_identifier ;
+unquoted_identifier  ::= letter { letter | digit | '_' | '$' } ;
+quoted_identifier    ::= '"' { qchar } '"' ;
+
+letter               ::= 'A'..'Z' | 'a'..'z' | '_' ;
+digit                ::= '0'..'9' ;
+qchar                ::= any_character_except('"') | '""' ;
+
+string_literal       ::= '\'' { schar } '\'' ;
+schar                ::= any_character_except('\'', '\\') | '\\' any_character ;
+
+numeric_literal      ::= integer_literal | decimal_literal | float_literal ;
+integer_literal      ::= digit { digit } ;
+decimal_literal      ::= digit { digit } '.' { digit } ;
+float_literal        ::= ( integer_literal | decimal_literal ) ( 'E' | 'e' ) [ '+' | '-' ] integer_literal ;
+
+boolean_literal      ::= 'TRUE' | 'FALSE' ;
+null_literal         ::= 'NULL' ;
+
+parameter_reference  ::= ':' identifier | '?' ; -- PSQL uses :name
+```
+
+Expressions and operators
+```ebnf
+expression            ::= or_expression ;
+or_expression         ::= and_expression { 'OR' and_expression } ;
+and_expression        ::= not_expression { 'AND' not_expression } ;
+not_expression        ::= [ 'NOT' ] comparison_expression ;
+
+comparison_expression ::= add_expression comparison_tail? ;
+comparison_tail       ::= comparison_operator add_expression
+                        | [ 'NOT' ] 'BETWEEN' add_expression 'AND' add_expression
+                        | [ 'NOT' ] 'IN' '(' in_list_or_subquery ')'
+                        | [ 'NOT' ] 'LIKE' add_expression [ 'ESCAPE' add_expression ]
+                        | 'IS' [ 'NOT' ] ( 'NULL' | 'TRUE' | 'FALSE' | 'UNKNOWN' ) ;
+
+comparison_operator   ::= '=' | '<>' | '!=' | '<' | '<=' | '>' | '>=' ;
+
+in_list_or_subquery   ::= expression { ',' expression } | select_statement ;
+
+add_expression        ::= mult_expression { ( '+' | '-' ) mult_expression } ;
+mult_expression       ::= unary_expression { ( '*' | '/' ) unary_expression } ;
+unary_expression      ::= [ '+' | '-' ] postfix_expression | 'EXISTS' '(' select_statement ')' | 'CASE' case_operand? when_clauses [ 'ELSE' expression ] 'END' ;
+case_operand          ::= expression ;
+when_clauses          ::= 'WHEN' expression 'THEN' expression { 'WHEN' expression 'THEN' expression } ;
+
+postfix_expression    ::= primary_expression postfix_suffix* ;
+postfix_suffix        ::= field_access | type_cast | collate_suffix ;
+field_access          ::= '.' identifier ;
+type_cast             ::= 'CAST' '(' expression 'AS' type_name ')' ;
+collate_suffix        ::= 'COLLATE' identifier ;
+
+primary_expression    ::= literal | parameter_reference | column_reference | function_call | select_subquery | '(' expression ')' ;
+literal               ::= numeric_literal | string_literal | boolean_literal | null_literal ;
+column_reference      ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+
+function_call         ::= function_name '(' [ expression_list ] ')' window_clause? ;
+function_name         ::= identifier [ '.' identifier ] ;
+expression_list       ::= expression { ',' expression } ;
+
+window_clause         ::= 'OVER' '(' [ 'PARTITION' 'BY' expression_list ] [ 'ORDER' 'BY' order_list ] [ frame_clause ] ')' ;
+order_list            ::= order_item { ',' order_item } ;
+order_item            ::= expression [ 'ASC' | 'DESC' ] ;
+frame_clause          ::= 'ROWS' frame_range ;
+frame_range           ::= frame_start | 'BETWEEN' frame_start 'AND' frame_end ;
+frame_start           ::= 'UNBOUNDED' 'PRECEDING' | expression 'PRECEDING' | 'CURRENT' 'ROW' ;
+frame_end             ::= 'CURRENT' 'ROW' | expression 'FOLLOWING' | 'UNBOUNDED' 'FOLLOWING' ;
+
+type_name             ::= identifier [ '(' expression_list ')' ] ;
+```
+
+Queries (SELECT, set operations, CTE)
+```ebnf
+select_statement      ::= [ with_clause ] select_core { set_operation select_core } [ order_by_clause ] [ rows_clause ] [ for_update_clause ] ;
+
+with_clause           ::= 'WITH' [ 'RECURSIVE' ] cte_definition { ',' cte_definition } ;
+cte_definition        ::= identifier [ '(' identifier { ',' identifier } ')' ] 'AS' '(' select_core { set_operation select_core } ')' ;
+
+set_operation         ::= 'UNION' [ 'ALL' | 'DISTINCT' ] | 'INTERSECT' | 'EXCEPT' ;
+
+select_core           ::= 'SELECT' [ 'ALL' | 'DISTINCT' ] select_list from_clause? where_clause? group_by_clause? having_clause? ;
+select_list           ::= select_item { ',' select_item } ;
+select_item           ::= expression [ alias ] | '*' | qualified_star ;
+qualified_star        ::= identifier '.' '*' | identifier '.' identifier '.' '*' ;
+alias                 ::= [ 'AS' ] identifier ;
+
+from_clause           ::= 'FROM' table_reference { ',' table_reference } ;
+table_reference       ::= table_factor joined_tail* ;
+table_factor          ::= relation_expr [ alias ] | '(' select_statement ')' [ alias ] | '(' table_reference ')' ;
+relation_expr         ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+joined_tail           ::= join_op table_factor [ join_condition ] ;
+join_op               ::= 'JOIN' | 'INNER' 'JOIN' | 'LEFT' [ 'OUTER' ] 'JOIN' | 'RIGHT' [ 'OUTER' ] 'JOIN' | 'FULL' [ 'OUTER' ] 'JOIN' | 'CROSS' 'JOIN' ;
+join_condition        ::= 'ON' expression | 'USING' '(' identifier { ',' identifier } ')' ;
+
+where_clause          ::= 'WHERE' expression ;
+group_by_clause       ::= 'GROUP' 'BY' expression_list ;
+having_clause         ::= 'HAVING' expression ;
+
+order_by_clause       ::= 'ORDER' 'BY' order_list ;
+rows_clause           ::= 'ROWS' integer_literal ; -- FIRST N, SKIP N also supported
+for_update_clause     ::= 'FOR' 'UPDATE' ;
+```
+
+DML (RETURNING, MERGE)
+```ebnf
+insert_statement      ::= 'INSERT' 'INTO' relation_expr [ '(' column_list ')' ] insert_source [ returning_clause ] ;
+insert_source         ::= 'VALUES' values_list | select_statement ;
+values_list           ::= '(' value_list ')' { ',' '(' value_list ')' } ;
+value_list            ::= expression { ',' expression } ;
+column_list           ::= identifier { ',' identifier } ;
+returning_clause      ::= 'RETURNING' return_list ;
+return_list           ::= '*' | expression_list ;
+
+update_statement      ::= 'UPDATE' relation_expr 'SET' set_list [ where_clause ] [ returning_clause ] ;
+set_list              ::= set_item { ',' set_item } ;
+set_item              ::= identifier '=' expression ;
+
+delete_statement      ::= 'DELETE' 'FROM' relation_expr [ where_clause ] [ returning_clause ] ;
+
+merge_statement       ::= 'MERGE' 'INTO' relation_expr 'USING' table_reference 'ON' expression merge_when { merge_when } [ returning_clause ] ;
+merge_when            ::= 'WHEN' 'MATCHED' 'THEN' merge_action | 'WHEN' 'NOT' 'MATCHED' 'THEN' merge_action ;
+merge_action          ::= 'UPDATE' 'SET' set_list [ where_clause ] | 'INSERT' '(' column_list ')' 'VALUES' '(' value_list ')' | 'DELETE' ;
+```
+
+DDL (domains, sequences/generators, computed columns)
+```ebnf
+create_domain         ::= 'CREATE' 'DOMAIN' identifier 'AS' type_name domain_constraints? ;
+domain_constraints    ::= { 'DEFAULT' expression | 'CHECK' '(' expression ')' | 'NOT' 'NULL' | 'NULL' } ;
+
+create_table          ::= 'CREATE' 'TABLE' relation_expr '(' table_element { ',' table_element } ')' ;
+table_element         ::= column_definition | table_constraint ;
+column_definition     ::= identifier type_name column_constraints? ;
+column_constraints    ::= { 'NOT' 'NULL' | 'NULL' | 'DEFAULT' expression | 'CHECK' '(' expression ')' | computed_column } ;
+computed_column       ::= 'COMPUTED' 'BY' '(' expression ')' ;
+
+table_constraint      ::= [ 'CONSTRAINT' identifier ] ( 'PRIMARY' 'KEY' '(' column_list ')' | 'UNIQUE' '(' column_list ')' | 'CHECK' '(' expression ')' | foreign_key ) ;
+foreign_key           ::= 'FOREIGN' 'KEY' '(' column_list ')' 'REFERENCES' relation_expr [ '(' column_list ')' ] [ ref_actions ] ;
+ref_actions           ::= [ 'ON' 'DELETE' ref_action ] [ 'ON' 'UPDATE' ref_action ] ;
+ref_action            ::= 'CASCADE' | 'SET' 'NULL' | 'SET' 'DEFAULT' | 'NO' 'ACTION' ;
+
+create_sequence       ::= 'CREATE' 'SEQUENCE' identifier sequence_opts? ;
+sequence_opts         ::= { 'START' 'WITH' integer_literal | 'INCREMENT' [ 'BY' ] integer_literal | 'MINVALUE' integer_literal | 'MAXVALUE' integer_literal | 'CACHE' integer_literal | 'CYCLE' | 'NOCYCLE' } ;
+
+drop_table            ::= 'DROP' 'TABLE' relation_expr ;
+drop_sequence         ::= 'DROP' 'SEQUENCE' identifier ;
+```
+
+PSQL blocks (procedural SQL)
+```ebnf
+psql_block            ::= 'BEGIN' psql_statements 'END' ;
+psql_statements       ::= { psql_statement ';' } ;
+psql_statement        ::= assignment | if_stmt | while_stmt | for_select_stmt | exception_stmt | execute_stmt | cursor_stmt | suspend_stmt | return_stmt | sql_statement ;
+
+variable_decl         ::= 'DECLARE' identifier type_name [ default_clause ] ;
+assignment            ::= identifier ':=' expression ;
+if_stmt               ::= 'IF' expression 'THEN' psql_statements [ 'ELSE' psql_statements ] 'END' 'IF' ;
+while_stmt            ::= 'WHILE' expression 'DO' psql_statements 'END' 'WHILE' ;
+for_select_stmt       ::= 'FOR' identifier 'AS' 'CURSOR' 'FOR' select_statement 'DO' psql_statements 'END' 'FOR' ;
+exception_stmt        ::= 'EXCEPTION' identifier [ ',' string_literal ] ;
+execute_stmt          ::= 'EXECUTE' 'STATEMENT' expression [ 'INTO' column_list ] ;
+cursor_stmt           ::= 'OPEN' identifier | 'CLOSE' identifier | 'FETCH' identifier 'INTO' column_list ;
+suspend_stmt          ::= 'SUSPEND' ;
+return_stmt           ::= 'RETURN' ;
+sql_statement         ::= insert_statement | update_statement | delete_statement | merge_statement | select_statement ;
+```
+
+Triggers, procedures, functions
+```ebnf
+create_trigger        ::= 'CREATE' 'TRIGGER' identifier trigger_position trigger_event 'ON' relation_expr 'AS' psql_block ;
+trigger_position      ::= 'BEFORE' | 'AFTER' ;
+trigger_event         ::= 'INSERT' | 'UPDATE' | 'DELETE' ;
+
+create_procedure      ::= 'CREATE' 'PROCEDURE' identifier '(' param_list? ')' [ 'RETURNS' '(' param_list ')' ] 'AS' declarations? psql_block ;
+create_function       ::= 'CREATE' 'FUNCTION' identifier '(' param_list? ')' 'RETURNS' type_name 'AS' declarations? psql_block ;
+param_list            ::= param_decl { ',' param_decl } ;
+param_decl            ::= identifier type_name ;
+declarations          ::= { variable_decl ';' } ;
+```
+
+Utilities
+```ebnf
+comment_statement     ::= 'COMMENT' 'ON' ( 'TABLE' relation_expr | 'COLUMN' relation_expr '.' identifier ) 'IS' ( string_literal | 'NULL' ) ;
+grant_statement       ::= 'GRANT' ... ; revoke_statement ::= 'REVOKE' ... ;
+set_statement         ::= 'SET' identifier '=' expression ;
+```
+
+Highlights
+- Firebird PSQL has explicit `BEGIN...END` blocks, variable declarations, and exception handling distinct from SQL/PSM.
+- `RETURNING` is widely supported on DML.
+- Computed columns via `COMPUTED BY` on tables; domains for reusable types.
+- Sequences (generators) exist; `NEXT VALUE FOR` usage in expressions is permitted.
+

--- a/references/sql_dialects/mysql_mariadb_ebnf.md
+++ b/references/sql_dialects/mysql_mariadb_ebnf.md
@@ -1,0 +1,278 @@
+### MySQL/MariaDB SQL Variations — EBNF Report
+
+Version scope: MySQL 8.0.x and MariaDB 10.6–11.x family features. Focus on dialect differences vs SQL Standard and between MySQL and MariaDB. Grammar aims to provide a parser blueprint; tokenization and version-conditional features may require flags.
+
+EBNF index:
+- Tokens and lexical peculiarities
+- Expressions and precedence (with MySQL boolean pragmatics)
+- Queries (SELECT, set ops, CTEs [MySQL 8], windowing)
+- DML (INSERT/REPLACE/UPSERT, UPDATE, DELETE) with RETURNING [MariaDB/MySQL 8.0.19+ limited]
+- DDL (CREATE/ALTER/DROP TABLE) with engine/charset/collations/partitions
+- Indexes, constraints, sequences/auto_increment, views
+- Routines (FUNCTION/PROCEDURE, triggers, events), partitions
+- Utility (EXPLAIN, ANALYZE, OPTIMIZE, SHOW, SET, GRANT)
+- Highlights and differences vs PostgreSQL/SQL Server
+
+Tokens and lexical peculiarities
+```ebnf
+identifier              ::= unquoted_identifier | quoted_identifier | backtick_identifier ;
+unquoted_identifier     ::= letter { letter | digit | '_' | '$' } ;
+quoted_identifier       ::= '"' { qchar } '"' ;
+backtick_identifier     ::= '`' { bchar } '`' ;
+
+letter                  ::= 'A'..'Z' | 'a'..'z' | '_' ;
+digit                   ::= '0'..'9' ;
+qchar                   ::= any_character_except('"') | '""' ;
+bchar                   ::= any_character_except('`') | '``' ;
+
+string_literal          ::= '\'' { schar } '\'' | '"' { qchar } '"' ;
+schar                   ::= any_character_except('\'', '\\') | '\\' any_character ;
+
+bit_literal             ::= 'b' '\'' { '0' | '1' } '\'' | '0b' { '0' | '1' } ;
+hex_literal             ::= 'x' '\'' { hex_digit } '\'' | '0x' { hex_digit } ;
+hex_digit               ::= digit | 'A'..'F' | 'a'..'f' ;
+
+numeric_literal         ::= integer_literal | decimal_literal | float_literal ;
+integer_literal         ::= digit { digit } ;
+decimal_literal         ::= digit { digit } '.' { digit } | '.' digit { digit } ;
+float_literal           ::= ( integer_literal | decimal_literal ) ( 'E' | 'e' ) [ '+' | '-' ] integer_literal ;
+
+boolean_literal         ::= 'TRUE' | 'FALSE' ;
+null_literal            ::= 'NULL' ;
+
+parameter_reference     ::= '?' | ':' identifier ;
+
+collation_name          ::= identifier ;
+charset_name            ::= identifier ;
+```
+
+Expressions and precedence
+```ebnf
+expression              ::= or_expression ;
+or_expression           ::= xor_expression { 'OR' xor_expression } ;
+xor_expression          ::= and_expression { 'XOR' and_expression } ;
+and_expression          ::= not_expression { 'AND' not_expression } ;
+not_expression          ::= [ 'NOT' | '!' ] comparison_expression ;
+
+comparison_expression   ::= add_expression comparison_tail? ;
+comparison_tail         ::= comparison_operator add_expression
+                          | [ 'NOT' ] 'BETWEEN' add_expression 'AND' add_expression
+                          | [ 'NOT' ] 'IN' '(' in_list_or_subquery ')'
+                          | [ 'NOT' ] 'LIKE' add_expression [ 'ESCAPE' add_expression ]
+                          | [ 'NOT' ] 'REGEXP' add_expression
+                          | 'IS' [ 'NOT' ] ( 'NULL' | 'TRUE' | 'FALSE' | 'UNKNOWN' ) ;
+
+comparison_operator     ::= '=' | '<=>' | '!=' | '<>' | '<' | '<=' | '>' | '>=' ;
+
+in_list_or_subquery    ::= expression { ',' expression } | select_statement ;
+
+add_expression         ::= mult_expression { ( '+' | '-' ) mult_expression } ;
+mult_expression        ::= unary_expression { ( '*' | '/' | 'DIV' | '%' | 'MOD' ) unary_expression } ;
+
+unary_expression       ::= [ '+' | '-' | '!' | '~' | 'BINARY' ] postfix_expression
+                         | 'EXISTS' '(' select_statement ')'
+                         | 'CASE' case_operand? when_clauses [ 'ELSE' expression ] 'END' ;
+
+case_operand           ::= expression ;
+when_clauses           ::= 'WHEN' expression 'THEN' expression { 'WHEN' expression 'THEN' expression } ;
+
+postfix_expression     ::= primary_expression postfix_suffix* ;
+postfix_suffix         ::= array_subscript | field_access | type_cast | collate_suffix ;
+array_subscript        ::= '[' expression ']' ;
+field_access           ::= '.' identifier ;
+type_cast              ::= 'CAST' '(' expression 'AS' type_name ')' ;
+collate_suffix         ::= 'COLLATE' collation_name ;
+
+primary_expression     ::= literal | parameter_reference | column_reference | function_call | select_subquery | '(' expression ')' ;
+literal                ::= numeric_literal | string_literal | hex_literal | bit_literal | boolean_literal | null_literal ;
+column_reference       ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+
+function_call          ::= function_name '(' [ function_args ] ')' window_clause? ;
+function_name          ::= identifier [ '.' identifier ] ;
+function_args          ::= [ 'DISTINCT' ] expression { ',' expression } | named_args ;
+named_args             ::= arg_assignment { ',' arg_assignment } ;
+arg_assignment         ::= identifier '=>' expression ;
+
+window_clause          ::= 'OVER' ( window_name | window_spec ) ;
+window_name            ::= identifier ;
+window_spec            ::= '(' [ 'PARTITION' 'BY' expression_list ] [ 'ORDER' 'BY' order_list ] [ frame_clause ] ')' ;
+expression_list        ::= expression { ',' expression } ;
+order_list             ::= order_item { ',' order_item } ;
+order_item             ::= expression [ 'ASC' | 'DESC' ] ;
+
+frame_clause           ::= frame_type frame_range ;
+frame_type             ::= 'RANGE' | 'ROWS' ;
+frame_range            ::= frame_start | 'BETWEEN' frame_start 'AND' frame_end ;
+frame_start            ::= 'UNBOUNDED' 'PRECEDING' | expression 'PRECEDING' | 'CURRENT' 'ROW' ;
+frame_end              ::= 'CURRENT' 'ROW' | expression 'FOLLOWING' | 'UNBOUNDED' 'FOLLOWING' ;
+
+type_name              ::= identifier [ '(' expression_list ')' ] [ 'UNSIGNED' ] [ 'ZEROFILL' ] ;
+```
+
+Queries (SELECT, set operations, CTE)
+```ebnf
+select_statement       ::= [ with_clause ] select_core { set_operation select_core } [ order_by_clause ] [ limit_clause ] [ lock_clause ] ;
+
+with_clause            ::= 'WITH' [ 'RECURSIVE' ] cte_definition { ',' cte_definition } ;
+cte_definition         ::= identifier [ '(' identifier { ',' identifier } ')' ] 'AS' '(' select_core { set_operation select_core } ')' ;
+
+set_operation          ::= 'UNION' [ 'ALL' | 'DISTINCT' ] | 'INTERSECT' [ 'ALL' ] | 'EXCEPT' [ 'ALL' ] ;
+
+select_core            ::= 'SELECT' [ 'ALL' | 'DISTINCT' ] select_list from_clause? where_clause? group_by_clause? having_clause? window_definitions? ;
+select_list            ::= select_item { ',' select_item } ;
+select_item            ::= expression [ alias ] | '*' | qualified_star ;
+qualified_star         ::= identifier '.' '*' | identifier '.' identifier '.' '*' ;
+alias                  ::= [ 'AS' ] identifier ;
+
+from_clause            ::= 'FROM' table_reference { ',' table_reference } ;
+table_reference        ::= table_factor joined_tail* ;
+table_factor           ::= relation_expr [ alias ] [ index_hint ]
+                         | '(' select_statement ')' [ alias ]
+                         | '(' table_reference ')' ;
+relation_expr          ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+index_hint             ::= 'USE' 'INDEX' '(' index_list ')' | 'IGNORE' 'INDEX' '(' index_list ')' | 'FORCE' 'INDEX' '(' index_list ')' ;
+index_list             ::= identifier { ',' identifier } ;
+
+joined_tail            ::= join_op table_factor [ join_condition ] ;
+join_op                ::= 'JOIN' | 'INNER' 'JOIN' | 'LEFT' [ 'OUTER' ] 'JOIN' | 'RIGHT' [ 'OUTER' ] 'JOIN' | 'CROSS' 'JOIN' | 'STRAIGHT_JOIN' ;
+join_condition         ::= 'ON' expression | 'USING' '(' identifier { ',' identifier } ')' ;
+
+where_clause           ::= 'WHERE' expression ;
+group_by_clause        ::= 'GROUP' 'BY' expression_list [ 'WITH' 'ROLLUP' ] ;
+having_clause          ::= 'HAVING' expression ;
+
+window_definitions     ::= 'WINDOW' window_def { ',' window_def } ;
+window_def             ::= window_name 'AS' window_spec ;
+
+order_by_clause        ::= 'ORDER' 'BY' order_list ;
+limit_clause           ::= 'LIMIT' ( integer_literal [ ',' integer_literal ] | integer_literal 'OFFSET' integer_literal ) ;
+lock_clause            ::= 'FOR' ( 'UPDATE' | 'SHARE' ) ;
+```
+
+DML: INSERT/REPLACE/UPSERT, UPDATE, DELETE
+```ebnf
+insert_statement       ::= 'INSERT' [ 'IGNORE' ] 'INTO' relation_expr [ '(' column_list ')' ] insert_source [ on_duplicate_clause ] [ returning_clause ] ;
+replace_statement      ::= 'REPLACE' 'INTO' relation_expr [ '(' column_list ')' ] insert_source [ returning_clause ] ;
+column_list            ::= identifier { ',' identifier } ;
+insert_source          ::= 'VALUES' values_list | select_statement | 'SET' set_assign_list ;
+values_list            ::= '(' value_list ')' { ',' '(' value_list ')' } ;
+value_list             ::= expression { ',' expression } ;
+set_assign_list        ::= set_assign { ',' set_assign } ;
+set_assign             ::= identifier '=' expression ;
+
+on_duplicate_clause    ::= 'ON' 'DUPLICATE' 'KEY' 'UPDATE' set_assign_list ;
+returning_clause       ::= 'RETURNING' select_list ;
+
+update_statement       ::= 'UPDATE' [ 'LOW_PRIORITY' ] [ 'IGNORE' ] table_reference 'SET' set_assign_list [ where_clause ] [ order_by_clause ] [ limit_clause ] ;
+delete_statement       ::= 'DELETE' [ 'LOW_PRIORITY' ] [ 'QUICK' ] [ 'IGNORE' ] 'FROM' relation_expr [ using_join ] [ where_clause ] [ order_by_clause ] [ limit_clause ] ;
+using_join             ::= 'USING' table_reference ;
+```
+
+DDL: CREATE/ALTER/DROP TABLE, partitions, engine/charset
+```ebnf
+create_table          ::= 'CREATE' [ 'TEMPORARY' ] 'TABLE' [ 'IF' 'NOT' 'EXISTS' ] relation_expr '(' table_element { ',' table_element } ')' table_options? [ partition_clause ] ;
+table_element         ::= column_definition | table_constraint ;
+column_definition     ::= identifier type_name column_attributes? ;
+column_attributes     ::= { nullability | default_clause | auto_increment | comment | column_format | storage | collate_suffix | generated_column } ;
+nullability           ::= 'NULL' | 'NOT' 'NULL' ;
+default_clause        ::= 'DEFAULT' expression ;
+auto_increment        ::= 'AUTO_INCREMENT' ;
+comment               ::= 'COMMENT' string_literal ;
+column_format         ::= 'COLUMN_FORMAT' ( 'FIXED' | 'DYNAMIC' | 'DEFAULT' ) ;
+storage               ::= 'STORAGE' ( 'DISK' | 'MEMORY' | 'DEFAULT' ) ;
+generated_column      ::= 'GENERATED' 'ALWAYS' 'AS' '(' expression ')' ( 'VIRTUAL' | 'STORED' )
+                        | 'AS' '(' expression ')' ( 'VIRTUAL' | 'PERSISTENT' | 'STORED' ) ;
+
+table_constraint      ::= [ 'CONSTRAINT' identifier ] ( primary_key | unique_key | foreign_key | check_constraint ) ;
+primary_key           ::= 'PRIMARY' 'KEY' '(' index_col_list ')' index_options? ;
+unique_key            ::= 'UNIQUE' [ 'KEY' | 'INDEX' ] [ identifier ] '(' index_col_list ')' index_options? ;
+foreign_key           ::= 'FOREIGN' 'KEY' [ identifier ] '(' column_list ')' 'REFERENCES' relation_expr '(' column_list ')' reference_options? ;
+check_constraint      ::= 'CHECK' '(' expression ')' ;
+
+index_col_list        ::= index_col { ',' index_col } ;
+index_col             ::= identifier [ '(' integer_literal ')' ] [ 'ASC' | 'DESC' ] ;
+index_options         ::= { 'USING' identifier | 'KEY_BLOCK_SIZE' '=' integer_literal | 'WITH' 'PARSER' identifier | 'COMMENT' string_literal | 'VISIBLE' | 'INVISIBLE' } ;
+
+table_options         ::= { engine | charset | collate | row_format | auto_increment_opt | comment | compression | encryption } ;
+engine                ::= 'ENGINE' '=' identifier ;
+charset               ::= ( 'DEFAULT' )? ( 'CHARSET' | 'CHARACTER' 'SET' ) '=' charset_name ;
+collate               ::= 'COLLATE' '=' collation_name ;
+row_format            ::= 'ROW_FORMAT' '=' ( 'DEFAULT' | 'DYNAMIC' | 'FIXED' | 'COMPRESSED' | 'REDUNDANT' | 'COMPACT' ) ;
+auto_increment_opt    ::= 'AUTO_INCREMENT' '=' integer_literal ;
+compression           ::= 'COMPRESSION' '=' string_literal ;
+encryption            ::= 'ENCRYPTION' '=' ( 'Y' | 'N' ) ;
+
+partition_clause      ::= 'PARTITION' 'BY' partition_method ;
+partition_method      ::= 'RANGE' '(' partition_expr ')' partition_defs
+                        | 'LIST' '(' partition_expr ')' partition_defs
+                        | 'HASH' '(' partition_expr ')' partition_defs
+                        | 'LINEAR' 'HASH' '(' partition_expr ')' partition_defs
+                        | 'KEY' '(' column_list ')' partition_defs ;
+partition_expr        ::= expression ;
+partition_defs        ::= '(' partition_def { ',' partition_def } ')' ;
+partition_def         ::= 'PARTITION' identifier partition_options ;
+partition_options     ::= { 'VALUES' ('LESS' 'THAN' '(' expression_list ')' | 'IN' '(' expression_list ')' ) | 'ENGINE' '=' identifier | 'COMMENT' string_literal | 'DATA' 'DIRECTORY' string_literal | 'INDEX' 'DIRECTORY' string_literal } ;
+
+alter_table           ::= 'ALTER' 'TABLE' relation_expr alter_action { ',' alter_action } ;
+alter_action          ::= 'ADD' [ 'COLUMN' ] column_definition
+                        | 'ADD' table_constraint
+                        | 'DROP' [ 'COLUMN' ] identifier
+                        | 'DROP' 'PRIMARY' 'KEY'
+                        | 'DROP' 'FOREIGN' 'KEY' identifier
+                        | 'MODIFY' [ 'COLUMN' ] column_definition
+                        | 'CHANGE' [ 'COLUMN' ] identifier column_definition
+                        | 'RENAME' [ 'TO' ] relation_expr
+                        | 'CONVERT' 'TO' 'CHARACTER' 'SET' charset_name [ 'COLLATE' collation_name ]
+                        | 'ALTER' 'PARTITION' partition_alter ;
+
+partition_alter       ::= 'ADD' 'PARTITION' '(' partition_def { ',' partition_def } ')' | 'DROP' 'PARTITION' identifier { ',' identifier } | 'REORGANIZE' 'PARTITION' identifier 'INTO' '(' partition_def { ',' partition_def } ')' ;
+
+drop_table            ::= 'DROP' 'TABLE' [ 'IF' 'EXISTS' ] relation_expr { ',' relation_expr } ;
+```
+
+Indexes, sequences/auto_increment, views
+```ebnf
+create_index          ::= 'CREATE' [ 'UNIQUE' | 'FULLTEXT' | 'SPATIAL' ] 'INDEX' [ identifier ] 'ON' relation_expr '(' index_col_list ')' index_options? ;
+drop_index            ::= 'DROP' 'INDEX' identifier 'ON' relation_expr ;
+
+create_view           ::= 'CREATE' [ 'OR' 'REPLACE' ] 'VIEW' relation_expr [ '(' column_list ')' ] 'AS' select_statement [ 'WITH' 'CHECK' 'OPTION' ] ;
+drop_view             ::= 'DROP' 'VIEW' [ 'IF' 'EXISTS' ] relation_expr { ',' relation_expr } ;
+```
+
+Routines, triggers, events
+```ebnf
+create_function       ::= 'CREATE' 'FUNCTION' identifier '(' param_list? ')' 'RETURNS' type_name routine_characteristics routine_body ;
+create_procedure      ::= 'CREATE' 'PROCEDURE' identifier '(' param_list? ')' routine_characteristics routine_body ;
+param_list            ::= param_decl { ',' param_decl } ;
+param_decl            ::= [ 'IN' | 'OUT' | 'INOUT' ] identifier type_name ;
+routine_characteristics ::= { 'LANGUAGE' 'SQL' | 'DETERMINISTIC' | 'NOT' 'DETERMINISTIC' | 'READS' 'SQL' 'DATA' | 'MODIFIES' 'SQL' 'DATA' | 'CONTAINS' 'SQL' | 'NO' 'SQL' | 'COMMENT' string_literal | 'SQL' 'SECURITY' ( 'DEFINER' | 'INVOKER' ) } ;
+routine_body          ::= 'BEGIN' ... 'END' ;
+
+create_trigger        ::= 'CREATE' 'TRIGGER' identifier trigger_timing trigger_event 'ON' relation_expr 'FOR' 'EACH' ( 'ROW' | 'STATEMENT' ) trigger_body ;
+trigger_timing        ::= 'BEFORE' | 'AFTER' ;
+trigger_event         ::= 'INSERT' | 'UPDATE' | 'DELETE' ;
+trigger_body          ::= 'BEGIN' ... 'END' ;
+
+create_event          ::= 'CREATE' 'EVENT' identifier 'ON' 'SCHEDULE' schedule 'DO' routine_body ;
+schedule              ::= 'AT' expression | 'EVERY' expression [ 'STARTS' expression ] [ 'ENDS' expression ] ;
+```
+
+Utility and session
+```ebnf
+explain_statement     ::= 'EXPLAIN' [ 'ANALYZE' ] [ 'FORMAT' '=' ( 'TREE' | 'JSON' | 'TRADITIONAL' ) ] ( select_statement | insert_statement | update_statement | delete_statement | replace_statement ) ;
+optimize_table        ::= 'OPTIMIZE' 'TABLE' relation_expr { ',' relation_expr } ;
+analyze_table         ::= 'ANALYZE' 'TABLE' relation_expr { ',' relation_expr } ;
+show_statement        ::= 'SHOW' show_what ;
+show_what             ::= 'DATABASES' | 'TABLES' | 'COLUMNS' 'FROM' relation_expr | 'INDEX' 'FROM' relation_expr | 'CREATE' 'TABLE' relation_expr | 'ENGINE' 'INNODB' 'STATUS' | identifier ;
+set_statement         ::= 'SET' set_item { ',' set_item } ;
+set_item              ::= identifier '=' expression | 'NAMES' charset_name [ 'COLLATE' collation_name ] | 'CHARACTER' 'SET' charset_name ;
+grant_statement       ::= 'GRANT' ... ; revoke_statement ::= 'REVOKE' ... ;
+```
+
+Highlights and differences
+- MySQL NULL-safe `<=>`, `REGEXP`, JSON functions instead of JSON operators; MariaDB varies in native JSON types.
+- `REPLACE` is MySQL/MariaDB-specific. UPSERT via `ON DUPLICATE KEY UPDATE` differs from PostgreSQL `ON CONFLICT`.
+- Window functions exist; no GROUPS frame. Partial `RETURNING` support varies by version and engine.
+- Character sets/collations are pervasive; `CHARSET`, `COLLATE` appear on many objects.
+- Partitioning syntax differs from PostgreSQL; storage engines and index visibility are dialect-specific.
+

--- a/references/sql_dialects/postgresql_ebnf.md
+++ b/references/sql_dialects/postgresql_ebnf.md
@@ -1,0 +1,504 @@
+### PostgreSQL SQL Extensions — EBNF Report
+
+Version scope: PostgreSQL 15–16 family features with emphasis on PostgreSQL-specific extensions beyond SQL Standard. This grammar is suitable as a starting point for implementing a full SQL parser. It focuses on statement- and expression-level structure and dials into PostgreSQL-specific clauses and operators. Tokenization and some edge-case ambiguities (especially around user-defined operators) may require additional lexer support.
+
+Notation: EBNF, case-insensitive keywords, `[...]` optional, `{...}` zero-or-more, `|` alternation, `()` grouping. Terminals are quoted with single quotes. Nonterminals are in snake_case. Comments beginning with `--` explain dialect notes.
+
+Implementation notes:
+- PostgreSQL allows user-defined operators with flexible symbolic names. Operator tokenization should consider the longest-match rule and the documented operator character classes.
+- Identifiers: unquoted identifiers fold to lower case. Quoted identifiers preserve case and allow otherwise-illegal characters.
+- String constants use standard conforming strings by default; escape string syntax `E'...'` supports C-style escapes.
+- Dollar-quoted strings: `$$...$$` or `$tag$...$tag$` appear in function bodies but may occur in SQL expressions too.
+- Many features are gated by object existence (`IF [NOT] EXISTS`) and privilege; grammar admits these regardless of runtime validation.
+
+EBNF index:
+- Tokens and lexical categories
+- Expressions and operator precedence
+- Queries (SELECT, set ops, CTEs, windowing)
+- DML (INSERT/UPSERT, UPDATE, DELETE, MERGE) with RETURNING
+- DDL (CREATE/ALTER/DROP TABLE, constraints, partitioning, inheritance)
+- Indexes, constraints, sequences, types, views/materialized views
+- Functions/procedures/triggers, extensions, schemas
+- Utility (COPY, EXPLAIN/ANALYZE, VACUUM, ANALYZE, COMMENT, GRANT/REVOKE, SET)
+
+Tokens and lexical categories
+```ebnf
+identifier           ::= unquoted_identifier | quoted_identifier ;
+unquoted_identifier  ::= letter { letter | digit | '_' | '$' } ; -- folds to lower case
+quoted_identifier    ::= '"' { qchar } '"' ; -- doubled quotes inside
+
+letter               ::= 'A'..'Z' | 'a'..'z' | '_' ;
+digit                ::= '0'..'9' ;
+qchar                ::= any_character_except('"') | '""' ;
+
+numeric_literal      ::= integer_literal | decimal_literal | float_literal ;
+integer_literal      ::= digit { digit } ;
+decimal_literal      ::= digit { digit } '.' { digit } | '.' digit { digit } ;
+float_literal        ::= ( integer_literal | decimal_literal ) ( 'E' | 'e' ) [ '+' | '-' ] integer_literal ;
+
+string_literal       ::= quote { schar } quote ;
+quote                ::= '\'' ;
+schar                ::= any_character_except('\'', '\\') | '\\' any_character ;
+escape_string        ::= 'E' string_literal ;
+dollar_string        ::= '$' [ tag ] '$' { any_character_until_matching_tag } '$' [ tag ] '$' ;
+tag                  ::= letter { letter | digit | '_' } ;
+
+bytea_literal        ::= 'X' '\'' hex_pair { hex_pair } '\'' ;
+hex_pair             ::= hex_digit hex_digit ;
+hex_digit            ::= digit | 'A'..'F' | 'a'..'f' ;
+
+boolean_literal      ::= 'TRUE' | 'FALSE' ;
+null_literal         ::= 'NULL' ;
+
+parameter_reference  ::= '$' integer_literal ;            -- positional: $1, $2
+named_parameter      ::= ':' identifier ;                 -- allowed in some clients, not core PG parser
+
+type_identifier      ::= identifier [ '.' identifier ] [ '.' identifier ] ; -- schema/type/attribute
+collation_identifier ::= identifier [ '.' identifier ] ;
+```
+
+Expressions and operator precedence
+```ebnf
+expression               ::= or_expression ;
+
+or_expression            ::= and_expression { 'OR' and_expression } ;
+and_expression           ::= not_expression { 'AND' not_expression } ;
+
+not_expression           ::= [ 'NOT' ] comparison_expression ;
+
+comparison_expression    ::= add_expression comparison_tail? ;
+comparison_tail          ::= comparison_operator add_expression
+                           | 'IS' [ 'NOT' ] 'NULL'
+                           | 'IS' [ 'NOT' ] 'TRUE'
+                           | 'IS' [ 'NOT' ] 'FALSE'
+                           | 'IS' [ 'NOT' ] 'UNKNOWN'
+                           | 'IS' [ 'NOT' ] 'DISTINCT' 'FROM' add_expression
+                           | [ 'NOT' ] 'BETWEEN' add_expression 'AND' add_expression
+                           | [ 'NOT' ] 'IN' '(' in_list_or_subquery ')'
+                           | [ 'NOT' ] like_op add_expression [ 'ESCAPE' add_expression ]
+                           | [ 'NOT' ] 'SIMILAR' 'TO' add_expression [ 'ESCAPE' add_expression ] ;
+
+comparison_operator      ::= '=' | '!=' | '<>' | '<' | '<=' | '>' | '>=' ;
+like_op                  ::= 'LIKE' | 'ILIKE' ; -- ILIKE is PostgreSQL-specific
+
+in_list_or_subquery     ::= expression { ',' expression }
+                          | select_statement ;
+
+add_expression          ::= mult_expression { ( '+' | '-' ) mult_expression } ;
+mult_expression         ::= unary_expression { ( '*' | '/' | '%' ) unary_expression } ;
+
+unary_expression        ::= [ '+' | '-' | '~' ] postfix_expression
+                          | 'EXISTS' '(' select_statement ')'
+                          | 'CASE' case_operand? when_clauses [ 'ELSE' expression ] 'END' ;
+
+case_operand            ::= expression ;
+when_clauses            ::= 'WHEN' expression 'THEN' expression { 'WHEN' expression 'THEN' expression } ;
+
+postfix_expression      ::= primary_expression postfix_suffix* ;
+postfix_suffix          ::= array_subscript
+                          | field_access
+                          | type_cast
+                          | 'COLLATE' collation_identifier
+                          | 'AT' 'TIME' 'ZONE' expression ;
+
+array_subscript         ::= '[' ( expression [ ':' expression ] ) ']' ; -- slice or single element
+field_access            ::= '.' identifier ;                         -- composite fields / JSON path helper in funcs
+type_cast               ::= '::' type_name
+                          | 'CAST' '(' expression 'AS' type_name ')' ;
+
+primary_expression      ::= literal
+                          | parameter_reference
+                          | column_reference
+                          | row_constructor
+                          | array_constructor
+                          | function_call
+                          | select_subquery
+                          | '(' expression ')' ;
+
+literal                 ::= numeric_literal | string_literal | escape_string | dollar_string | boolean_literal | null_literal | bytea_literal ;
+
+column_reference        ::= identifier [ '.' identifier ] [ '.' identifier ] ; -- c.schema.table.column
+
+row_constructor         ::= 'ROW' '(' expression_list ')'
+                          | '(' expression_list ')' ; -- ambiguous with grouping; parser resolves contextually
+expression_list         ::= expression { ',' expression } ;
+
+array_constructor       ::= 'ARRAY' '[' expression_list ']'
+                          | 'ARRAY' '(' select_statement ')' ;
+
+function_call           ::= function_name '(' [ function_args ] ')' window_clause? filter_clause? ;
+function_name           ::= identifier [ '.' identifier ] ;
+function_args           ::= [ 'DISTINCT' ] expression { ',' expression }
+                          | named_args ;
+named_args              ::= arg_assignment { ',' arg_assignment } ;
+arg_assignment          ::= identifier '=>' expression ;
+
+filter_clause           ::= 'FILTER' '(' 'WHERE' expression ')' ;       -- aggregate FILTER (WHERE ...)
+window_clause           ::= 'OVER' ( window_name | window_specification ) ;
+window_name             ::= identifier ;
+window_specification    ::= '(' [ 'PARTITION' 'BY' expression_list ]
+                                 [ 'ORDER' 'BY' order_list ]
+                                 [ frame_clause ] ')' ;
+order_list              ::= order_item { ',' order_item } ;
+order_item              ::= expression [ 'COLLATE' collation_identifier ] [ 'ASC' | 'DESC' ] [ 'NULLS' 'FIRST' | 'NULLS' 'LAST' ] ;
+
+frame_clause            ::= frame_type frame_range [ frame_exclusion ] ;
+frame_type              ::= 'RANGE' | 'ROWS' | 'GROUPS' ;
+frame_range             ::= frame_start | 'BETWEEN' frame_start 'AND' frame_end ;
+frame_start             ::= 'UNBOUNDED' 'PRECEDING'
+                          | expression 'PRECEDING'
+                          | 'CURRENT' 'ROW' ;
+frame_end               ::= 'CURRENT' 'ROW'
+                          | expression 'FOLLOWING'
+                          | 'UNBOUNDED' 'FOLLOWING' ;
+frame_exclusion         ::= 'EXCLUDE' ( 'CURRENT' 'ROW' | 'GROUP' | 'TIES' | 'NO' 'OTHERS' ) ;
+
+type_name               ::= type_identifier [ type_modifiers ] | array_type ;
+type_modifiers          ::= '(' expression_list ')' ;
+array_type              ::= type_name '[]' ; -- right-recursive array suffixes
+```
+
+PostgreSQL-specific operators and constructs (non-exhaustive)
+```ebnf
+json_operator           ::= '->' | '->>' | '#>' | '#>>' | '@>' | '<@' | '?' | '?|' | '?&' ;
+string_operator         ::= '||' ;
+range_operator          ::= '<<' | '>>' | '&<' | '&>' | '&&' | '-' | '+' ;
+network_operator        ::= '<<' | '<<=' | '>>' | '>>=' | '&&' | '~' | '~*' ;
+text_search_operator    ::= '@@' | '@@' '!' | '@@' '?' ;
+```
+
+Queries (SELECT, set operations, CTE)
+```ebnf
+select_statement        ::= [ with_clause ] query_expression [ order_by_clause ] [ limit_offset_clause ] [ locking_clause ] ;
+
+with_clause             ::= 'WITH' [ 'RECURSIVE' ] cte_definition { ',' cte_definition } ;
+cte_definition          ::= identifier [ '(' identifier { ',' identifier } ')' ]
+                            'AS' [ 'NOT' 'MATERIALIZED' | 'MATERIALIZED' ] '(' query_expression ')' ;
+
+query_expression        ::= select_core { set_operation [ 'ALL' | 'DISTINCT' ] select_core } ;
+set_operation           ::= 'UNION' | 'INTERSECT' | 'EXCEPT' ;
+
+select_core             ::= 'SELECT' [ 'ALL' | 'DISTINCT' [ 'ON' '(' expression_list ')' ] ]
+                            select_list
+                            [ from_clause ]
+                            [ where_clause ]
+                            [ group_by_clause ]
+                            [ having_clause ]
+                            [ window_definitions ] ;
+
+select_list             ::= select_item { ',' select_item } ;
+select_item             ::= expression [ alias ] | '*' | qualified_star ;
+qualified_star          ::= identifier '.' '*' | identifier '.' identifier '.' '*' ;
+alias                   ::= [ 'AS' ] identifier ;
+
+from_clause             ::= 'FROM' from_item { ',' from_item } ;
+from_item               ::= table_reference
+                          | joined_table
+                          | lateral_item
+                          | function_table
+                          | '(' query_expression ')' [ alias ] ;
+
+table_reference         ::= relation_expr [ alias ] [ tablesample ] ;
+relation_expr           ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+
+tablesample             ::= 'TABLESAMPLE' method '(' expression_list ')' [ 'REPEATABLE' '(' expression ')' ] ;
+method                  ::= identifier ;
+
+lateral_item            ::= 'LATERAL' '(' query_expression ')' [ alias ] ;
+function_table          ::= function_call [ 'AS' ] [ alias ] [ '(' column_alias_list ')' ] ;
+column_alias_list       ::= identifier { ',' identifier } ;
+
+joined_table            ::= from_item join_tail ;
+join_tail               ::= join_op from_item [ join_condition ] { join_op from_item [ join_condition ] } ;
+join_op                 ::= [ 'NATURAL' ] ( 'JOIN' | 'INNER' 'JOIN' | 'LEFT' [ 'OUTER' ] 'JOIN' | 'RIGHT' [ 'OUTER' ] 'JOIN' | 'FULL' [ 'OUTER' ] 'JOIN' | 'CROSS' 'JOIN' ) ;
+join_condition          ::= 'ON' expression | 'USING' '(' identifier { ',' identifier } ')' ;
+
+where_clause            ::= 'WHERE' expression ;
+group_by_clause         ::= 'GROUP' 'BY' group_list ;
+group_list              ::= grouping_element { ',' grouping_element } ;
+grouping_element        ::= expression | '(' expression_list ')' | 'GROUPING' 'SETS' '(' group_list { ',' group_list } ')' | 'ROLLUP' '(' expression_list ')' | 'CUBE' '(' expression_list ')' ;
+having_clause           ::= 'HAVING' expression ;
+
+window_definitions      ::= 'WINDOW' window_def { ',' window_def } ;
+window_def              ::= window_name 'AS' window_specification ;
+
+order_by_clause         ::= 'ORDER' 'BY' order_list ;
+
+limit_offset_clause     ::= ( 'LIMIT' expression [ 'OFFSET' expression ] )
+                          | ( 'OFFSET' expression [ 'LIMIT' expression ] )
+                          | ( 'FETCH' ( 'FIRST' | 'NEXT' ) [ expression ] ( 'ROW' | 'ROWS' ) ( 'ONLY' | 'WITH' 'TIES' ) ) ;
+
+locking_clause          ::= ( 'FOR' lock_strength [ 'OF' identifier { ',' identifier } ] [ 'NOWAIT' | 'SKIP' 'LOCKED' ] ) { ',' 'FOR' lock_strength [ 'OF' identifier { ',' identifier } ] [ 'NOWAIT' | 'SKIP' 'LOCKED' ] } ;
+lock_strength           ::= 'UPDATE' | 'NO' 'KEY' 'UPDATE' | 'SHARE' | 'KEY' 'SHARE' ;
+```
+
+DML: INSERT / UPSERT, UPDATE, DELETE, MERGE (PostgreSQL 15+)
+```ebnf
+insert_statement        ::= 'INSERT' 'INTO' relation_expr [ '(' column_list ')' ]
+                            [ 'OVERRIDING' ( 'SYSTEM' | 'USER' ) 'VALUE' ]
+                            insert_source
+                            [ on_conflict_clause ]
+                            [ returning_clause ] ;
+
+column_list             ::= identifier { ',' identifier } ;
+insert_source           ::= 'DEFAULT' 'VALUES'
+                          | 'VALUES' values_list
+                          | select_statement ;
+values_list             ::= '(' value_list ')' { ',' '(' value_list ')' } ;
+value_list              ::= expression { ',' expression } ;
+
+on_conflict_clause      ::= 'ON' 'CONFLICT' ( '(' conflict_target ')' [ where_clause ] | 'ON' 'CONSTRAINT' identifier | )
+                            'DO' ( 'NOTHING' | 'UPDATE' 'SET' set_clause_list [ where_clause ] ) ;
+conflict_target         ::= index_expr_list [ 'INCLUDE' '(' column_list ')' ] ;
+index_expr_list         ::= index_expr { ',' index_expr } ;
+index_expr              ::= expression [ 'COLLATE' collation_identifier ] [ opclass ] [ 'ASC' | 'DESC' ] [ 'NULLS' 'FIRST' | 'LAST' ] ;
+opclass                 ::= identifier [ '(' identifier { ',' identifier } ')' ] ;
+
+returning_clause        ::= 'RETURNING' ( '*' | select_list ) ;
+
+update_statement        ::= 'UPDATE' [ 'ONLY' ] relation_expr [ '*' ] [ alias ]
+                            'SET' set_clause_list
+                            [ from_clause ]
+                            [ where_clause ]
+                            [ returning_clause ] ;
+set_clause_list         ::= set_clause { ',' set_clause } ;
+set_clause              ::= identifier [ '.' identifier ] '=' expression ;
+
+delete_statement        ::= 'DELETE' 'FROM' [ 'ONLY' ] relation_expr [ '*' ] [ alias ]
+                            [ using_clause ]
+                            [ where_clause | 'WHERE' 'CURRENT' 'OF' identifier ]
+                            [ returning_clause ] ;
+using_clause            ::= 'USING' from_item { ',' from_item } ;
+
+merge_statement         ::= 'MERGE' 'INTO' relation_expr [ alias ]
+                            'USING' ( relation_expr | '(' select_statement ')' [ alias ] )
+                            'ON' expression
+                            merge_when_clause { merge_when_clause }
+                            [ returning_clause ] ;
+merge_when_clause       ::= 'WHEN' 'MATCHED' [ 'AND' expression ] 'THEN' merge_action
+                          | 'WHEN' 'NOT' 'MATCHED' [ 'AND' expression ] 'THEN' merge_action ;
+merge_action            ::= 'DO' 'NOTHING'
+                          | 'UPDATE' 'SET' set_clause_list [ where_clause ]
+                          | 'INSERT' '(' column_list ')' 'VALUES' '(' value_list ')' [ where_clause ] ;
+```
+
+DDL: CREATE/ALTER/DROP TABLE, constraints, inheritance, partitioning
+```ebnf
+create_table           ::= 'CREATE' [ 'TEMP' | 'TEMPORARY' | 'UNLOGGED' ] 'TABLE' [ 'IF' 'NOT' 'EXISTS' ] relation_expr
+                           '(' table_element { ',' table_element } ')'
+                           [ table_inherits ]
+                           [ partition_by ]
+                           [ 'WITH' '(' storage_parameter_list ')' ]
+                           [ 'TABLESPACE' identifier ] ;
+
+table_element          ::= column_definition | table_constraint ;
+column_definition      ::= identifier type_name
+                           [ 'COLLATE' collation_identifier ]
+                           { column_constraint } ;
+
+storage_parameter_list ::= storage_parameter { ',' storage_parameter } ;
+storage_parameter      ::= identifier '=' expression ;
+
+column_constraint      ::= 'CONSTRAINT' identifier column_constraint_body | column_constraint_body ;
+column_constraint_body ::= 'NOT' 'NULL'
+                         | 'NULL'
+                         | 'DEFAULT' expression
+                         | 'GENERATED' ( 'ALWAYS' | 'BY' 'DEFAULT' ) 'AS' 'IDENTITY' [ '(' identity_options ')' ]
+                         | 'GENERATED' 'ALWAYS' 'AS' '(' expression ')' 'STORED'
+                         | 'PRIMARY' 'KEY'
+                         | 'UNIQUE'
+                         | 'REFERENCES' relation_expr [ '(' column_list ')' ] [ match_type ] [ referential_actions ]
+                         | 'CHECK' '(' expression ')' [ 'NO' 'INHERIT' ] ;
+
+identity_options       ::= identity_option { ',' identity_option } ;
+identity_option        ::= 'START' [ 'WITH' ] integer_literal
+                         | 'INCREMENT' [ 'BY' ] integer_literal
+                         | 'MINVALUE' integer_literal | 'NO' 'MINVALUE'
+                         | 'MAXVALUE' integer_literal | 'NO' 'MAXVALUE'
+                         | 'CACHE' integer_literal
+                         | 'CYCLE' | 'NO' 'CYCLE'
+                         | 'OWNED' 'BY' ( relation_expr '.' identifier | 'NONE' ) ;
+
+match_type             ::= 'MATCH' ( 'FULL' | 'PARTIAL' | 'SIMPLE' ) ;
+referential_actions    ::= [ 'ON' 'DELETE' ref_action ] [ 'ON' 'UPDATE' ref_action ] [ 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ] [ 'INITIALLY' ( 'DEFERRED' | 'IMMEDIATE' ) ] ;
+ref_action             ::= 'NO' 'ACTION' | 'RESTRICT' | 'CASCADE' | 'SET' 'NULL' | 'SET' 'DEFAULT' ;
+
+table_constraint       ::= [ 'CONSTRAINT' identifier ] table_constraint_body ;
+table_constraint_body  ::= 'PRIMARY' 'KEY' '(' index_expr_list ')'
+                         | 'UNIQUE' '(' index_expr_list ')'
+                         | 'CHECK' '(' expression ')' [ 'NO' 'INHERIT' ]
+                         | 'EXCLUDE' [ 'USING' index_method ] '(' exclude_element { ',' exclude_element } ')' [ 'WHERE' '(' expression ')' ] ;
+exclude_element        ::= index_expr 'WITH' operator_name [ 'ASC' | 'DESC' ] [ 'NULLS' 'FIRST' | 'LAST' ] ;
+operator_name          ::= identifier [ '.' identifier ] ;
+index_method           ::= identifier ;
+
+table_inherits         ::= 'INHERITS' '(' relation_expr { ',' relation_expr } ')' ;
+partition_by           ::= 'PARTITION' 'BY' partition_method ;
+partition_method       ::= 'RANGE' '(' index_expr_list ')' | 'LIST' '(' index_expr_list ')' | 'HASH' '(' index_expr_list ')' ;
+
+alter_table            ::= 'ALTER' 'TABLE' [ 'IF' 'EXISTS' ] relation_expr alter_table_action { ',' alter_table_action } ;
+alter_table_action     ::= 'ADD' [ 'COLUMN' ] column_definition
+                         | 'ADD' table_constraint
+                         | 'DROP' [ 'COLUMN' ] [ 'IF' 'EXISTS' ] identifier [ 'RESTRICT' | 'CASCADE' ]
+                         | 'DROP' [ 'CONSTRAINT' ] [ 'IF' 'EXISTS' ] identifier [ 'RESTRICT' | 'CASCADE' ]
+                         | 'ALTER' [ 'COLUMN' ] identifier alter_column_action
+                         | 'RENAME' [ 'COLUMN' ] identifier 'TO' identifier
+                         | 'RENAME' 'TO' identifier
+                         | 'SET' 'SCHEMA' identifier
+                         | 'ATTACH' 'PARTITION' relation_expr 'FOR' 'VALUES' partition_bound_spec
+                         | 'DETACH' 'PARTITION' relation_expr [ 'CONCURRENTLY' ] [ 'FINALIZE' ] ;
+
+alter_column_action    ::= 'SET' 'DEFAULT' expression
+                         | 'DROP' 'DEFAULT'
+                         | 'SET' 'NOT' 'NULL' | 'DROP' 'NOT' 'NULL'
+                         | 'TYPE' type_name [ 'USING' expression ]
+                         | 'ADD' 'GENERATED' 'ALWAYS' 'AS' '(' expression ')' 'STORED'
+                         | 'SET' 'STATISTICS' integer_literal
+                         | 'SET' 'IDENTITY' '(' identity_options ')'
+                         | 'ADD' 'IDENTITY' [ '(' identity_options ')' ]
+                         | 'DROP' 'IDENTITY' ;
+
+partition_bound_spec   ::= 'IN' '(' expression_list ')' | 'FROM' '(' expression_list ')' 'TO' '(' expression_list ')' | 'WITH' '(' 'MODULUS' integer_literal ',' 'REMAINDER' integer_literal ')' ;
+
+drop_table             ::= 'DROP' 'TABLE' [ 'IF' 'EXISTS' ] relation_expr { ',' relation_expr } [ 'CASCADE' | 'RESTRICT' ] ;
+```
+
+Indexes, sequences, types, views/materialized views
+```ebnf
+create_index           ::= 'CREATE' [ 'UNIQUE' ] 'INDEX' [ 'CONCURRENTLY' ] [ 'IF' 'NOT' 'EXISTS' ] identifier
+                           'ON' relation_expr [ 'USING' index_method ] '(' index_element { ',' index_element } ')'
+                           [ 'INCLUDE' '(' column_list ')' ]
+                           [ 'WHERE' expression ]
+                           [ 'TABLESPACE' identifier ] ;
+index_element          ::= index_expr [ opclass ] [ 'ASC' | 'DESC' ] [ 'NULLS' 'FIRST' | 'LAST' ] ;
+
+drop_index             ::= 'DROP' 'INDEX' [ 'CONCURRENTLY' ] [ 'IF' 'EXISTS' ] identifier { ',' identifier } [ 'CASCADE' | 'RESTRICT' ] ;
+
+create_sequence        ::= 'CREATE' 'SEQUENCE' [ 'IF' 'NOT' 'EXISTS' ] relation_expr [ sequence_options ] ;
+sequence_options       ::= sequence_option { sequence_option } ;
+sequence_option        ::= 'AS' type_name | 'INCREMENT' [ 'BY' ] integer_literal | 'MINVALUE' integer_literal | 'NO' 'MINVALUE' | 'MAXVALUE' integer_literal | 'NO' 'MAXVALUE' | 'START' [ 'WITH' ] integer_literal | 'CACHE' integer_literal | 'CYCLE' | 'OWNED' 'BY' ( relation_expr '.' identifier | 'NONE' ) ;
+
+create_type            ::= 'CREATE' 'TYPE' identifier ( 'AS' enum_type | 'AS' range_type | 'AS' composite_type ) ;
+enum_type              ::= 'ENUM' '(' string_literal { ',' string_literal } ')' ;
+range_type             ::= 'RANGE' '(' 'SUBTYPE' '=' type_name { ',' range_option } ')' ;
+range_option           ::= 'COLLATION' '=' collation_identifier | 'SUBTYPE_OPCLASS' '=' opclass | 'CANONICAL' '=' function_name | 'SUBTYPE_DIFF' '=' function_name ;
+composite_type         ::= '(' identifier type_name { ',' identifier type_name } ')' ;
+
+create_view            ::= 'CREATE' [ 'OR' 'REPLACE' ] [ 'TEMP' | 'TEMPORARY' ] 'VIEW' [ 'IF' 'NOT' 'EXISTS' ] relation_expr [ '(' column_list ')' ] 'AS' select_statement [ 'WITH' '(' view_option_list ')' ] ;
+view_option_list       ::= view_option { ',' view_option } ;
+view_option            ::= 'CHECK' 'OPTION' [ 'LOCAL' | 'CASCADED' ] ;
+
+create_materialized_view ::= 'CREATE' 'MATERIALIZED' 'VIEW' [ 'IF' 'NOT' 'EXISTS' ] relation_expr [ '(' column_list ')' ] 'AS' select_statement [ 'WITH' 'NO' 'DATA' | 'WITH' 'DATA' ] ;
+refresh_materialized_view ::= 'REFRESH' 'MATERIALIZED' 'VIEW' [ 'CONCURRENTLY' ] relation_expr [ 'WITH' 'NO' 'DATA' | 'WITH' 'DATA' ] ;
+```
+
+Functions, procedures, triggers, schemas, extensions
+```ebnf
+create_function        ::= 'CREATE' [ 'OR' 'REPLACE' ] 'FUNCTION' function_name '(' function_parameters? ')'
+                           'RETURNS' function_return
+                           function_properties
+                           'LANGUAGE' identifier
+                           function_body ;
+
+function_parameters    ::= function_parameter { ',' function_parameter } ;
+function_parameter     ::= [ 'IN' | 'OUT' | 'INOUT' | 'VARIADIC' ] identifier type_name [ default_clause ] ;
+default_clause         ::= 'DEFAULT' expression ;
+function_return        ::= type_name | 'TABLE' '(' identifier type_name { ',' identifier type_name } ')' ;
+function_properties    ::= { 'IMMUTABLE' | 'STABLE' | 'VOLATILE' | 'PARALLEL' ( 'SAFE' | 'RESTRICTED' | 'UNSAFE' ) | 'STRICT' | 'RETURNS' 'NULL' 'ON' 'NULL' 'INPUT' | 'CALLED' 'ON' 'NULL' 'INPUT' | 'SECURITY' ( 'DEFINER' | 'INVOKER' ) | 'LEAKPROOF' | cost_rows | set_config } ;
+cost_rows              ::= 'COST' numeric_literal | 'ROWS' numeric_literal ;
+set_config             ::= 'SET' identifier '=' expression ;
+function_body          ::= 'AS' dollar_string [ ',' dollar_string ]
+                         | 'AS' string_literal [ ',' string_literal ] ;
+
+create_procedure       ::= 'CREATE' [ 'OR' 'REPLACE' ] 'PROCEDURE' function_name '(' function_parameters? ')' [ procedure_properties ] 'LANGUAGE' identifier function_body ;
+procedure_properties   ::= { 'TRANSFORM' 'FOR' 'TYPE' '(' type_name { ',' type_name } ')' | 'SECURITY' ( 'DEFINER' | 'INVOKER' ) } ;
+
+create_trigger         ::= 'CREATE' 'TRIGGER' identifier trigger_timing trigger_events 'ON' relation_expr [ 'FOR' 'EACH' ( 'ROW' | 'STATEMENT' ) ] [ 'WHEN' '(' expression ')' ] 'EXECUTE' 'FUNCTION' function_name '(' [ expression_list ] ')' ;
+trigger_timing         ::= 'BEFORE' | 'AFTER' | 'INSTEAD' 'OF' ;
+trigger_events         ::= 'INSERT' | 'UPDATE' [ 'OF' column_list ] | 'DELETE' | 'TRUNCATE' ;
+
+create_schema          ::= 'CREATE' 'SCHEMA' [ 'IF' 'NOT' 'EXISTS' ] ( identifier | 'AUTHORIZATION' identifier ) ;
+
+create_extension       ::= 'CREATE' 'EXTENSION' [ 'IF' 'NOT' 'EXISTS' ] identifier [ 'WITH' '(' ext_option_list ')' ] ;
+ext_option_list        ::= ext_option { ',' ext_option } ;
+ext_option             ::= 'SCHEMA' '=' identifier | 'VERSION' '=' string_literal | 'CASCADE' ;
+```
+
+Utility and session
+```ebnf
+copy_statement         ::= 'COPY' ( relation_expr [ '(' column_list ')' ] | '(' select_statement ')' ) 'TO' program_or_file copy_with
+                         | 'COPY' relation_expr [ '(' column_list ')' ] 'FROM' program_or_file copy_with ;
+program_or_file        ::= string_literal | 'PROGRAM' string_literal | 'STDIN' | 'STDOUT' ;
+copy_with              ::= [ 'WITH' '(' copy_option { ',' copy_option } ')' ] ;
+copy_option            ::= 'FORMAT' '=' ( 'TEXT' | 'CSV' | 'BINARY' ) | 'DELIMITER' '=' string_literal | 'NULL' '=' string_literal | 'HEADER' '=' boolean_literal | 'QUOTE' '=' string_literal | 'ESCAPE' '=' string_literal | 'FORCE_QUOTE' '=' '(' column_list ')' | 'FORCE_NOT_NULL' '=' '(' column_list ')' | 'ENCODING' '=' string_literal ;
+
+explain_statement      ::= 'EXPLAIN' [ 'ANALYZE' ] [ 'VERBOSE' ] [ '(' explain_option { ',' explain_option } ')' ] ( select_statement | insert_statement | update_statement | delete_statement | merge_statement ) ;
+explain_option         ::= identifier [ '=' expression ] ;
+
+vacuum_statement       ::= 'VACUUM' [ '(' vacuum_option_list ')' ] [ relation_expr [ '(' column_list ')' ] ] ;
+vacuum_option_list     ::= vacuum_option { ',' vacuum_option } ;
+vacuum_option          ::= 'FULL' | 'FREEZE' | 'VERBOSE' | 'ANALYZE' | 'DISABLE_PAGE_SKIPPING' | 'SKIP_LOCKED' | 'INDEX_CLEANUP' '=' ( 'ON' | 'OFF' ) | 'TRUNCATE' '=' ( 'ON' | 'OFF' ) | 'PARALLEL' '=' integer_literal ;
+
+analyze_statement      ::= 'ANALYZE' [ 'VERBOSE' ] [ relation_expr [ '(' column_list ')' ] ] ;
+
+comment_statement      ::= 'COMMENT' 'ON' comment_target 'IS' ( string_literal | 'NULL' ) ;
+comment_target         ::= 'TABLE' relation_expr | 'COLUMN' relation_expr '.' identifier | 'INDEX' identifier | 'SCHEMA' identifier | 'FUNCTION' function_name '(' { type_name { ',' type_name } } ')' | 'AGGREGATE' function_name '(' type_name ')' | 'VIEW' relation_expr | 'MATERIALIZED' 'VIEW' relation_expr | 'SEQUENCE' relation_expr | 'TYPE' identifier ;
+
+grant_statement        ::= 'GRANT' privileges 'ON' privilege_target 'TO' grantee_list [ 'WITH' 'GRANT' 'OPTION' ] ;
+revoke_statement       ::= 'REVOKE' [ 'GRANT' 'OPTION' 'FOR' ] privileges 'ON' privilege_target 'FROM' grantee_list [ 'CASCADE' | 'RESTRICT' ] ;
+privileges             ::= ( 'ALL' [ 'PRIVILEGES' ] ) | privilege_list ;
+privilege_list         ::= privilege_item { ',' privilege_item } ;
+privilege_item         ::= 'SELECT' | 'INSERT' | 'UPDATE' [ '(' column_list ')' ] | 'DELETE' | 'TRUNCATE' | 'REFERENCES' [ '(' column_list ')' ] | 'TRIGGER' | 'USAGE' | 'CREATE' | 'CONNECT' | 'TEMPORARY' ;
+privilege_target       ::= 'TABLE' relation_expr | 'SEQUENCE' relation_expr | 'DATABASE' identifier | 'SCHEMA' identifier | 'FUNCTION' function_name | 'LANGUAGE' identifier | 'ALL' 'TABLES' 'IN' 'SCHEMA' identifier ;
+grantee_list           ::= grantee { ',' grantee } ;
+grantee                ::= identifier | 'PUBLIC' ;
+
+set_statement          ::= 'SET' ( 'SESSION' | 'LOCAL' )? set_parameter ;
+set_parameter          ::= identifier ( '=' | 'TO' ) ( expression | 'DEFAULT' ) | 'TIME' 'ZONE' ( expression | 'LOCAL' | 'DEFAULT' ) ;
+
+transaction_statement  ::= 'BEGIN' [ 'TRANSACTION' ] [ iso_level ] [ access_mode ] [ deferrable_mode ]
+                         | 'START' 'TRANSACTION' [ iso_level ] [ access_mode ] [ deferrable_mode ]
+                         | 'COMMIT' [ 'WORK' ] [ 'AND' 'NO' 'CHAIN' | 'AND' 'CHAIN' ]
+                         | 'ROLLBACK' [ 'WORK' ] [ 'AND' 'NO' 'CHAIN' | 'AND' 'CHAIN' ]
+                         | 'SAVEPOINT' identifier
+                         | 'RELEASE' 'SAVEPOINT' identifier
+                         | 'ROLLBACK' 'TO' [ 'SAVEPOINT' ] identifier ;
+iso_level              ::= 'ISOLATION' 'LEVEL' ( 'READ' 'UNCOMMITTED' | 'READ' 'COMMITTED' | 'REPEATABLE' 'READ' | 'SERIALIZABLE' ) ;
+access_mode            ::= 'READ' 'ONLY' | 'READ' 'WRITE' ;
+deferrable_mode        ::= 'DEFERRABLE' | 'NOT' 'DEFERRABLE' ;
+```
+
+Top-level statement list
+```ebnf
+statement               ::= select_statement
+                          | insert_statement
+                          | update_statement
+                          | delete_statement
+                          | merge_statement
+                          | create_table | alter_table | drop_table
+                          | create_index | drop_index
+                          | create_sequence | 'ALTER' 'SEQUENCE' ... | 'DROP' 'SEQUENCE' ...
+                          | create_type | 'DROP' 'TYPE' ...
+                          | create_view | create_materialized_view | refresh_materialized_view | 'DROP' 'VIEW' ... | 'DROP' 'MATERIALIZED' 'VIEW' ...
+                          | create_function | create_procedure | create_trigger | 'DROP' 'FUNCTION' ... | 'DROP' 'PROCEDURE' ... | 'DROP' 'TRIGGER' ...
+                          | create_schema | 'DROP' 'SCHEMA' ... | create_extension | 'ALTER' 'EXTENSION' ... | 'DROP' 'EXTENSION' ...
+                          | copy_statement | explain_statement | vacuum_statement | analyze_statement
+                          | comment_statement | grant_statement | revoke_statement | set_statement | transaction_statement
+                          | 'TRUNCATE' [ 'TABLE' ] relation_expr { ',' relation_expr } [ 'CONTINUE' 'IDENTITY' | 'RESTART' 'IDENTITY' ] [ 'CASCADE' | 'RESTRICT' ] ;
+
+sql_script              ::= { statement ';' } ;
+```
+
+Dialect highlights and parser considerations
+- PostgreSQL supports `DISTINCT ON ( ... )` in `SELECT`.
+- LATERAL subqueries and function tables are first-class.
+- Arrays: type-suffixed arrays (`int[]`) and `ARRAY[...]` constructors with slicing syntax.
+- JSON/JSONB: extensive operators (->, ->>, @>, <@, ? etc.) and functions; operators should be tokenized ahead of precedence resolution.
+- UPSERT via `INSERT ... ON CONFLICT ... DO ...` supports index expression targets and partial index predicates (`WHERE` in conflict target).
+- Table partitioning and table inheritance coexist; `ONLY table` affects scans in UPDATE/DELETE/TRUNCATE.
+- Exclusion constraints with operator classes.
+- Identity and generated stored columns.
+- Window frames include `GROUPS` and frame exclusions.
+- `MERGE` follows SQL:2016 semantics in PG15+ with some PostgreSQL-specific behaviors.
+
+This EBNF is intentionally modular so expression grammar and statement grammar can be reused in other dialect grammars.

--- a/references/sql_dialects/tsql_mssql_ebnf.md
+++ b/references/sql_dialects/tsql_mssql_ebnf.md
@@ -1,0 +1,221 @@
+### T-SQL (Microsoft SQL Server) — EBNF Report
+
+Version scope: SQL Server 2019–2022 features. Focus on T‑SQL constructs: TOP/OFFSET, APPLY, OUTPUT clause, MERGE, table hints, proprietary functions, and procedural T‑SQL (BEGIN...END, DECLARE, TRY/CATCH).
+
+EBNF index:
+- Tokens and lexical items
+- Expressions and precedence
+- Queries (SELECT, set ops, CTE, TOP/OFFSET, APPLY, table hints)
+- DML (INSERT with OUTPUT, UPDATE, DELETE, MERGE)
+- DDL (tables, computed columns, sequences, indexes, schemas, views)
+- Procedural T‑SQL (variables, control flow, error handling)
+- Utilities (EXEC, sp_executesql, SET, GRANT/REVOKE)
+
+Tokens and lexical items
+```ebnf
+identifier             ::= unquoted_identifier | quoted_identifier | bracket_identifier ;
+unquoted_identifier    ::= letter { letter | digit | '_' | '$' } ;
+quoted_identifier      ::= '"' { qchar } '"' ;
+bracket_identifier     ::= '[' { bchar } ']' ;
+
+letter                 ::= 'A'..'Z' | 'a'..'z' | '_' ;
+digit                  ::= '0'..'9' ;
+qchar                  ::= any_character_except('"') | '""' ;
+bchar                  ::= any_character_except(']') | ']]' ;
+
+string_literal         ::= '\'' { schar } '\'' ;
+schar                  ::= any_character_except('\'', '\\') | '\\' any_character ;
+
+numeric_literal        ::= integer_literal | decimal_literal | float_literal ;
+integer_literal        ::= digit { digit } ;
+decimal_literal        ::= digit { digit } '.' { digit } | '.' digit { digit } ;
+float_literal          ::= ( integer_literal | decimal_literal ) ( 'E' | 'e' ) [ '+' | '-' ] integer_literal ;
+
+binary_literal         ::= '0x' { hex_digit } ;
+hex_digit              ::= digit | 'A'..'F' | 'a'..'f' ;
+
+boolean_literal        ::= 'TRUE' | 'FALSE' ; -- treated as bit 1/0 in some contexts
+null_literal           ::= 'NULL' ;
+
+parameter_reference    ::= '@' identifier ;
+```
+
+Expressions and precedence
+```ebnf
+expression             ::= or_expression ;
+or_expression          ::= and_expression { 'OR' and_expression } ;
+and_expression         ::= not_expression { 'AND' not_expression } ;
+not_expression         ::= [ 'NOT' ] comparison_expression ;
+
+comparison_expression  ::= add_expression comparison_tail? ;
+comparison_tail        ::= comparison_operator add_expression
+                         | [ 'NOT' ] 'BETWEEN' add_expression 'AND' add_expression
+                         | [ 'NOT' ] 'IN' '(' in_list_or_subquery ')'
+                         | [ 'NOT' ] 'LIKE' add_expression [ 'ESCAPE' add_expression ]
+                         | 'IS' [ 'NOT' ] ( 'NULL' | 'TRUE' | 'FALSE' | 'UNKNOWN' ) ;
+
+comparison_operator    ::= '=' | '!=' | '<>' | '<' | '<=' | '>' | '>=' ;
+
+in_list_or_subquery    ::= expression { ',' expression } | select_statement ;
+
+add_expression         ::= mult_expression { ( '+' | '-' | '|' ) mult_expression } ; -- bitwise or included
+mult_expression        ::= unary_expression { ( '*' | '/' | '%' | '&' | '^' ) unary_expression } ;
+
+unary_expression       ::= [ '+' | '-' | '~' ] postfix_expression
+                         | 'EXISTS' '(' select_statement ')'
+                         | 'CASE' case_operand? when_clauses [ 'ELSE' expression ] 'END' ;
+
+case_operand           ::= expression ;
+when_clauses           ::= 'WHEN' expression 'THEN' expression { 'WHEN' expression 'THEN' expression } ;
+
+postfix_expression     ::= primary_expression postfix_suffix* ;
+postfix_suffix         ::= field_access | type_cast | collate_suffix ;
+field_access           ::= '.' identifier ;
+type_cast              ::= 'CAST' '(' expression 'AS' type_name ')' | 'CONVERT' '(' type_name ',' expression ')' ;
+collate_suffix         ::= 'COLLATE' identifier ;
+
+primary_expression     ::= literal | parameter_reference | column_reference | function_call | select_subquery | '(' expression ')' ;
+literal                ::= numeric_literal | string_literal | binary_literal | boolean_literal | null_literal ;
+column_reference       ::= identifier [ '.' identifier ] [ '.' identifier ] [ '.' identifier ] ;
+
+function_call          ::= function_name '(' [ function_args ] ')' window_clause? ;
+function_name          ::= identifier [ '.' identifier ] ;
+function_args          ::= [ 'DISTINCT' ] expression { ',' expression } ;
+
+window_clause          ::= 'OVER' ( window_name | window_spec ) ;
+window_name            ::= identifier ;
+window_spec            ::= '(' [ 'PARTITION' 'BY' expression_list ] [ 'ORDER' 'BY' order_list ] [ rows_range ] ')' ;
+expression_list        ::= expression { ',' expression } ;
+order_list             ::= order_item { ',' order_item } ;
+order_item             ::= expression [ 'ASC' | 'DESC' ] ;
+rows_range             ::= 'ROWS' frame_range | 'RANGE' frame_range ;
+frame_range            ::= frame_start | 'BETWEEN' frame_start 'AND' frame_end ;
+frame_start            ::= 'UNBOUNDED' 'PRECEDING' | expression 'PRECEDING' | 'CURRENT' 'ROW' ;
+frame_end              ::= 'CURRENT' 'ROW' | expression 'FOLLOWING' | 'UNBOUNDED' 'FOLLOWING' ;
+
+type_name              ::= identifier [ '(' expression_list ')' ] ;
+```
+
+Queries (SELECT, CTE, APPLY, hints)
+```ebnf
+select_statement       ::= [ with_clause ] select_core { set_operation select_core } [ order_by_clause ] [ offset_fetch ] [ table_hint_clause ] ;
+
+with_clause            ::= 'WITH' [ 'RECURSIVE' ]? cte_definition { ',' cte_definition } ; -- SQL Server uses WITH; recursion via UNION ALL
+cte_definition         ::= identifier [ '(' identifier { ',' identifier } ')' ] 'AS' '(' select_core { set_operation select_core } ')' ;
+
+set_operation          ::= 'UNION' [ 'ALL' | 'DISTINCT' ] | 'INTERSECT' | 'EXCEPT' ;
+
+select_core            ::= 'SELECT' [ 'ALL' | 'DISTINCT' ] [ top_clause ] select_list from_clause? where_clause? group_by_clause? having_clause? ;
+top_clause             ::= 'TOP' ( integer_literal | parameter_reference | '(' expression ')' ) [ 'PERCENT' ] [ 'WITH' 'TIES' ] ;
+select_list            ::= select_item { ',' select_item } ;
+select_item            ::= expression [ alias ] | '*' | qualified_star ;
+qualified_star         ::= identifier '.' '*' | identifier '.' identifier '.' '*' ;
+alias                  ::= [ 'AS' ] identifier ;
+
+from_clause            ::= 'FROM' table_reference { ',' table_reference } ;
+table_reference        ::= table_factor joined_tail* ;
+table_factor           ::= relation_expr [ alias ] [ table_sample ]
+                         | '(' select_statement ')' [ alias ]
+                         | '(' table_reference ')' ;
+relation_expr          ::= identifier [ '.' identifier ] [ '.' identifier ] ;
+table_sample           ::= 'TABLESAMPLE' 'SYSTEM' '(' integer_literal 'PERCENT' ')' ;
+
+joined_tail            ::= join_op table_factor [ join_condition ] ;
+join_op                ::= 'JOIN' | 'INNER' 'JOIN' | 'LEFT' [ 'OUTER' ] 'JOIN' | 'RIGHT' [ 'OUTER' ] 'JOIN' | 'FULL' [ 'OUTER' ] 'JOIN' | 'CROSS' 'JOIN' | 'APPLY' | 'CROSS' 'APPLY' | 'OUTER' 'APPLY' ;
+join_condition         ::= 'ON' expression ;
+
+where_clause           ::= 'WHERE' expression ;
+group_by_clause        ::= 'GROUP' 'BY' expression_list [ 'WITH' 'ROLLUP' ] ;
+having_clause          ::= 'HAVING' expression ;
+
+order_by_clause        ::= 'ORDER' 'BY' order_list ;
+offset_fetch           ::= 'OFFSET' integer_literal 'ROWS' [ 'FETCH' ( 'FIRST' | 'NEXT' ) integer_literal 'ROWS' ( 'ONLY' | 'WITH' 'TIES' ) ] ;
+
+table_hint_clause      ::= 'OPTION' '(' hint_list ')' ;
+hint_list              ::= hint { ',' hint } ;
+hint                   ::= identifier [ '(' expression_list ')' ] ;
+```
+
+DML (OUTPUT, MERGE)
+```ebnf
+insert_statement       ::= 'INSERT' 'INTO' relation_expr [ '(' column_list ')' ] insert_source [ output_clause ] ;
+insert_source          ::= 'DEFAULT' 'VALUES' | 'VALUES' values_list | select_statement ;
+values_list            ::= '(' value_list ')' { ',' '(' value_list ')' } ;
+value_list             ::= expression { ',' expression } ;
+column_list            ::= identifier { ',' identifier } ;
+
+output_clause          ::= 'OUTPUT' output_list [ 'INTO' relation_expr '(' column_list ')' ] ;
+output_list            ::= expression { ',' expression } ; -- inserted.*, deleted.* supported via virtual tables
+
+update_statement       ::= 'UPDATE' relation_expr 'SET' set_list [ from_clause ] [ where_clause ] [ output_clause ] ;
+set_list               ::= set_item { ',' set_item } ;
+set_item               ::= identifier '=' expression ;
+
+delete_statement       ::= 'DELETE' 'FROM' relation_expr [ from_clause ] [ where_clause ] [ output_clause ] ;
+
+merge_statement        ::= 'MERGE' 'INTO' relation_expr [ alias ] 'USING' ( relation_expr | '(' select_statement ')' [ alias ] ) 'ON' expression merge_when { merge_when } [ output_clause ] ;
+merge_when             ::= 'WHEN' 'MATCHED' [ 'AND' expression ] 'THEN' merge_action | 'WHEN' 'NOT' 'MATCHED' [ 'AND' expression ] 'THEN' merge_action ;
+merge_action           ::= 'UPDATE' 'SET' set_list [ where_clause ] | 'DELETE' | 'INSERT' '(' column_list ')' 'VALUES' '(' value_list ')' [ where_clause ] ;
+```
+
+DDL (tables, indexes, sequences, views)
+```ebnf
+create_table           ::= 'CREATE' 'TABLE' relation_expr '(' table_element { ',' table_element } ')' ;
+table_element          ::= column_definition | table_constraint ;
+column_definition      ::= identifier type_name column_constraints? ;
+column_constraints     ::= { 'NULL' | 'NOT' 'NULL' | 'DEFAULT' expression | 'IDENTITY' '(' integer_literal ',' integer_literal ')' | computed_column } ;
+computed_column        ::= 'AS' '(' expression ')' [ 'PERSISTED' ] ;
+
+table_constraint       ::= [ 'CONSTRAINT' identifier ] ( 'PRIMARY' 'KEY' '(' column_list ')' | 'UNIQUE' '(' column_list ')' | 'CHECK' '(' expression ')' | foreign_key ) ;
+foreign_key            ::= 'FOREIGN' 'KEY' '(' column_list ')' 'REFERENCES' relation_expr '(' column_list ')' [ ref_actions ] ;
+ref_actions            ::= [ 'ON' 'DELETE' ref_action ] [ 'ON' 'UPDATE' ref_action ] ;
+ref_action             ::= 'NO' 'ACTION' | 'CASCADE' | 'SET' 'NULL' | 'SET' 'DEFAULT' ;
+
+create_sequence        ::= 'CREATE' 'SEQUENCE' relation_expr sequence_options? ;
+sequence_options       ::= { 'AS' type_name | 'START' 'WITH' integer_literal | 'INCREMENT' 'BY' integer_literal | 'MINVALUE' integer_literal | 'MAXVALUE' integer_literal | 'CYCLE' | 'CACHE' integer_literal | 'NO' 'CYCLE' } ;
+
+create_index           ::= 'CREATE' [ 'UNIQUE' ] 'INDEX' identifier 'ON' relation_expr '(' index_col_list ')' ;
+index_col_list         ::= index_col { ',' index_col } ;
+index_col              ::= identifier [ 'ASC' | 'DESC' ] ;
+
+create_view            ::= 'CREATE' [ 'OR' 'ALTER' ] 'VIEW' relation_expr [ '(' column_list ')' ] 'AS' select_statement ;
+```
+
+Procedural T‑SQL
+```ebnf
+batch                  ::= { batch_statement } ;
+batch_statement        ::= sql_statement ';' | block_statement ;
+
+block_statement        ::= 'BEGIN' statement_list 'END' ;
+statement_list         ::= { statement_item } ;
+statement_item         ::= sql_statement ';' | declare_statement ';' | set_statement ';' | control_statement ';' | try_catch_block ;
+
+declare_statement      ::= 'DECLARE' declare_item { ',' declare_item } ;
+declare_item           ::= parameter_reference type_name [ '=' expression ] ;
+
+set_statement          ::= 'SET' parameter_reference '=' expression | 'SET' 'NOCOUNT' 'ON' | 'SET' 'NOCOUNT' 'OFF' ;
+
+control_statement      ::= if_statement | while_statement | cursor_statement | return_statement | print_statement ;
+if_statement           ::= 'IF' expression block_statement [ 'ELSE' block_statement ] ;
+while_statement        ::= 'WHILE' expression block_statement ;
+cursor_statement       ::= 'DECLARE' identifier 'CURSOR' 'FOR' select_statement | 'OPEN' identifier | 'FETCH' identifier 'INTO' column_list | 'CLOSE' identifier | 'DEALLOCATE' identifier ;
+return_statement       ::= 'RETURN' [ expression ] ;
+print_statement        ::= 'PRINT' expression ;
+
+try_catch_block        ::= 'BEGIN' 'TRY' statement_list 'END' 'TRY' 'BEGIN' 'CATCH' statement_list 'END' 'CATCH' ;
+
+sql_statement          ::= select_statement | insert_statement | update_statement | delete_statement | merge_statement | create_table | create_index | create_sequence | create_view ;
+```
+
+Utilities
+```ebnf
+exec_statement         ::= 'EXEC' ( function_name [ expression_list ] | 'sp_executesql' string_literal [ ',' exec_params ] ) ;
+exec_params            ::= parameter_reference '=' expression { ',' parameter_reference '=' expression } ;
+grant_statement        ::= 'GRANT' ... ; revoke_statement ::= 'REVOKE' ... ;
+```
+
+Highlights
+- T‑SQL `TOP` and `OFFSET/FETCH` coexist; `APPLY` supports table-valued functions.
+- `OUTPUT` clause exposes `inserted`/`deleted` pseudo-tables across DML.
+- Procedural T‑SQL provides `BEGIN/END`, variables with `@`, and robust `TRY/CATCH`.
+


### PR DESCRIPTION
Add comprehensive EBNF reports for PostgreSQL, MySQL/MariaDB, Firebird, and T-SQL to facilitate AI-driven SQL parser re-implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca25e22f-8483-4fec-9fa0-4864c6f51dda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca25e22f-8483-4fec-9fa0-4864c6f51dda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

