### PR TITLE
Generate SQL dialect BNF/EBNF reports

### DIFF
--- a/references/sql_dialects/firebird_sql_psql_bnf_ebnf.md
+++ b/references/sql_dialects/firebird_sql_psql_bnf_ebnf.md
@@ -1,0 +1,1064 @@
+# Firebird SQL/PSQL BNF/EBNF Grammar
+
+## Overview
+This document provides a comprehensive BNF/EBNF grammar specification for Firebird SQL and PSQL (Procedural SQL). Firebird is an open-source SQL relational database management system that extends the SQL standard with numerous features, particularly strong support for stored procedures, triggers, and a rich procedural language.
+
+## Notation
+- `::=` defines a production rule
+- `|` indicates alternatives
+- `[ ]` indicates optional elements
+- `{ }` indicates zero or more repetitions
+- `( )` groups elements
+- `< >` denotes non-terminals
+- Terminal symbols are in UPPERCASE or quoted
+- `/* Version */` indicates version-specific features
+
+## Core Grammar
+
+### 1. Data Types
+
+```ebnf
+<firebird_data_type> ::=
+    <numeric_type>
+  | <character_type>
+  | <date_time_type>
+  | <binary_type>
+  | <boolean_type>
+  | <array_type>
+  | <domain_type>
+
+<numeric_type> ::=
+    SMALLINT
+  | INTEGER | INT
+  | BIGINT
+  | INT128  /* Firebird 4.0+ */
+  | FLOAT [ ( <precision> ) ]
+  | REAL
+  | DOUBLE PRECISION
+  | DECIMAL [ ( <precision> [ , <scale> ] ) ]
+  | NUMERIC [ ( <precision> [ , <scale> ] ) ]
+  | DECFLOAT [ ( { 16 | 34 } ) ]  /* Firebird 4.0+ */
+
+<character_type> ::=
+    CHAR [ ( <length> ) ] [ CHARACTER SET <charset_name> ]
+  | CHARACTER [ ( <length> ) ] [ CHARACTER SET <charset_name> ]
+  | VARCHAR ( <length> ) [ CHARACTER SET <charset_name> ]
+  | CHARACTER VARYING ( <length> ) [ CHARACTER SET <charset_name> ]
+  | NCHAR [ ( <length> ) ]
+  | NATIONAL { CHAR | CHARACTER } [ ( <length> ) ]
+  | NVARCHAR ( <length> )
+  | NATIONAL { CHAR | CHARACTER } VARYING ( <length> )
+
+<date_time_type> ::=
+    DATE
+  | TIME [ { WITH | WITHOUT } TIME ZONE ]  /* Firebird 4.0+ */
+  | TIMESTAMP [ { WITH | WITHOUT } TIME ZONE ]  /* WITH TIME ZONE: Firebird 4.0+ */
+
+<binary_type> ::=
+    BLOB [ SUB_TYPE { <subtype_number> | <subtype_name> } ]
+        [ SEGMENT SIZE <segment_size> ]
+        [ CHARACTER SET <charset_name> ]
+
+<boolean_type> ::= BOOLEAN  /* Firebird 3.0+ */
+
+<array_type> ::=
+    <base_type> [ <array_dimensions> ]
+
+<array_dimensions> ::=
+    '[' [ <lower_bound> : ] <upper_bound> { , [ <lower_bound> : ] <upper_bound> } ']'
+
+<domain_type> ::= <domain_name>
+```
+
+### 2. DDL Statements
+
+#### CREATE TABLE
+
+```ebnf
+<create_table_statement> ::=
+    CREATE [ { GLOBAL | LOCAL } { TEMPORARY | TEMP } ] TABLE <table_name>
+    [ EXTERNAL [ FILE ] '<filespec>' ]
+    ( <table_element> { , <table_element> } )
+    [ ON COMMIT { DELETE | PRESERVE } ROWS ]  /* For temporary tables */
+
+<table_element> ::=
+    <column_definition>
+  | <table_constraint>
+  | <like_clause>  /* Firebird 3.0+ */
+
+<column_definition> ::=
+    <column_name> { <data_type> | <domain_name> | COMPUTED BY ( <expression> ) }
+    [ DEFAULT { <literal> | NULL | <context_variable> | <expression> } ]
+    [ [ NOT ] NULL ]
+    [ <column_constraint> { <column_constraint> } ]
+    [ COLLATE <collation_name> ]
+
+<column_constraint> ::=
+    [ CONSTRAINT <constraint_name> ]
+    { PRIMARY KEY
+    | UNIQUE
+    | REFERENCES <table_name> [ ( <column_name> ) ]
+        [ ON DELETE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ ON UPDATE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+    | CHECK ( <expression> )
+    | GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY 
+        [ ( <identity_options> ) ]  /* Firebird 3.0+ */ }
+
+<identity_options> ::=
+    [ START WITH <value> ]
+    [ INCREMENT [ BY ] <value> ]
+
+<table_constraint> ::=
+    [ CONSTRAINT <constraint_name> ]
+    { PRIMARY KEY ( <column_list> ) [ USING [ { ASC | DESC } ] INDEX <index_name> ]
+    | UNIQUE ( <column_list> ) [ USING [ { ASC | DESC } ] INDEX <index_name> ]
+    | FOREIGN KEY ( <column_list> ) REFERENCES <table_name> [ ( <column_list> ) ]
+        [ ON DELETE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ ON UPDATE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+    | CHECK ( <expression> ) }
+```
+
+#### CREATE INDEX
+
+```ebnf
+<create_index_statement> ::=
+    CREATE [ UNIQUE ] [ { ASC | DESC } ] INDEX <index_name>
+    ON <table_name> { ( <column_list> ) | COMPUTED BY ( <expression> ) }
+    [ WHERE <search_condition> ]  /* Firebird 5.0+ partial index */
+```
+
+#### CREATE VIEW
+
+```ebnf
+<create_view_statement> ::=
+    CREATE [ OR ALTER ] VIEW <view_name> [ ( <column_list> ) ]
+    AS <select_statement>
+    [ WITH CHECK OPTION ]
+```
+
+#### CREATE DOMAIN
+
+```ebnf
+<create_domain_statement> ::=
+    CREATE DOMAIN <domain_name> [ AS ] <data_type>
+    [ DEFAULT { <literal> | NULL | <context_variable> } ]
+    [ [ NOT ] NULL ]
+    [ CHECK ( <expression> ) ]
+    [ COLLATE <collation_name> ]
+```
+
+#### CREATE SEQUENCE/GENERATOR
+
+```ebnf
+<create_sequence_statement> ::=
+    CREATE { SEQUENCE | GENERATOR } <sequence_name>
+    [ START WITH <value> ]
+    [ INCREMENT [ BY ] <value> ]  /* SEQUENCE syntax: Firebird 3.0+ */
+```
+
+#### CREATE EXCEPTION
+
+```ebnf
+<create_exception_statement> ::=
+    CREATE [ OR ALTER ] EXCEPTION <exception_name> '<message_text>'
+    [ USING ( <parameter_list> ) ]  /* Firebird 5.0+ */
+```
+
+### 3. DML Statements
+
+#### INSERT
+
+```ebnf
+<insert_statement> ::=
+    INSERT INTO <table_or_view_name> [ ( <column_list> ) ]
+    { DEFAULT VALUES
+    | VALUES ( <value_list> )
+    | <select_statement>
+    | <execute_block_statement> }
+    [ RETURNING <column_list> [ INTO <variable_list> ] ]
+
+<merge_statement> ::=
+    MERGE INTO <target_table> [ [ AS ] <alias> ]
+    USING <source> ON <search_condition>
+    [ <merge_when_clause> { <merge_when_clause> } ]
+    [ PLAN <plan_clause> ]
+    [ ORDER BY <order_list> ]  /* Firebird 5.0+ */
+    [ RETURNING <column_list> [ INTO <variable_list> ] ]
+
+<merge_when_clause> ::=
+    WHEN MATCHED [ AND <condition> ] THEN 
+        { UPDATE SET <assignment_list> | DELETE }
+  | WHEN NOT MATCHED [ BY TARGET ] [ AND <condition> ] THEN
+        INSERT [ ( <column_list> ) ] VALUES ( <value_list> )
+  | WHEN NOT MATCHED BY SOURCE [ AND <condition> ] THEN
+        { UPDATE SET <assignment_list> | DELETE }  /* Firebird 5.0+ */
+
+<update_or_insert_statement> ::=
+    UPDATE OR INSERT INTO <table_or_view_name> [ ( <column_list> ) ]
+    VALUES ( <value_list> )
+    [ MATCHING ( <column_list> ) ]
+    [ RETURNING <column_list> [ INTO <variable_list> ] ]
+```
+
+#### UPDATE
+
+```ebnf
+<update_statement> ::=
+    UPDATE <table_or_view_name> [ [ AS ] <alias> ]
+    SET <assignment_list>
+    [ WHERE <search_condition> | WHERE CURRENT OF <cursor_name> ]
+    [ PLAN <plan_clause> ]
+    [ ORDER BY <order_list> ]
+    [ ROWS <value> [ TO <value> ] ]
+    [ SKIP [ LOCKED ] ]  /* Firebird 5.0+ */
+    [ RETURNING <column_list> [ INTO <variable_list> ] ]
+
+<assignment> ::=
+    <column_name> = { <expression> | DEFAULT }
+```
+
+#### DELETE
+
+```ebnf
+<delete_statement> ::=
+    DELETE FROM <table_or_view_name> [ [ AS ] <alias> ]
+    [ WHERE <search_condition> | WHERE CURRENT OF <cursor_name> ]
+    [ PLAN <plan_clause> ]
+    [ ORDER BY <order_list> ]
+    [ ROWS <value> [ TO <value> ] ]
+    [ SKIP [ LOCKED ] ]  /* Firebird 5.0+ */
+    [ RETURNING <column_list> [ INTO <variable_list> ] ]
+```
+
+#### SELECT
+
+```ebnf
+<select_statement> ::=
+    [ <with_clause> ]  /* Firebird 2.1+ */
+    SELECT [ { ALL | DISTINCT | FIRST <value> [ SKIP <value> ] | SKIP <value> } ]
+    <select_list>
+    FROM <table_reference_list>
+    [ WHERE <search_condition> ]
+    [ GROUP BY <grouping_element_list> ]
+    [ HAVING <search_condition> ]
+    [ WINDOW <window_definition_list> ]  /* Firebird 3.0+ */
+    [ PLAN <plan_clause> ]
+    [ UNION [ { ALL | DISTINCT } ] <select_statement> ]
+    [ ORDER BY <order_list> ]
+    [ { ROWS <value> [ TO <value> ] | OFFSET <value> [ { ROW | ROWS } ] 
+        [ FETCH { FIRST | NEXT } [ <value> ] { ROW | ROWS } ONLY ] } ]
+    [ FOR { UPDATE [ OF <column_list> ] | LOCK } [ WITH LOCK ] [ SKIP LOCKED ] ]
+    [ INTO <variable_list> ]  /* PSQL only */
+    [ AS CURSOR <cursor_name> ]  /* PSQL only, Firebird 3.0+ */
+
+<with_clause> ::=
+    WITH [ RECURSIVE ] <cte> { , <cte> }
+
+<cte> ::=
+    <cte_name> [ ( <column_list> ) ] AS ( <select_statement> )
+
+<select_list> ::=
+    *
+  | <select_item> { , <select_item> }
+
+<select_item> ::=
+    [ <table_name> . ] *
+  | <expression> [ [ AS ] <alias> ]
+
+<table_reference> ::=
+    <table_primary>
+  | <joined_table>
+
+<table_primary> ::=
+    <table_or_view_name> [ [ AS ] <alias> ]
+  | ( <select_statement> ) [ AS ] <alias>
+  | <procedure_name> ( [ <argument_list> ] ) [ AS ] <alias>
+  | LATERAL <derived_table> [ AS ] <alias>  /* Firebird 4.0+ */
+
+<joined_table> ::=
+    <table_reference> [ <join_type> ] JOIN <table_primary> <join_specification>
+
+<join_type> ::=
+    INNER | { LEFT | RIGHT | FULL } [ OUTER ] | CROSS
+
+<join_specification> ::=
+    ON <search_condition>
+  | USING ( <column_list> )
+  | NATURAL
+
+<grouping_element> ::=
+    <expression>
+  | ROLLUP ( <expression_list> )  /* Firebird 4.0+ */
+  | CUBE ( <expression_list> )    /* Firebird 4.0+ */
+  | GROUPING SETS ( <grouping_element_list> )  /* Firebird 4.0+ */
+  | ( )
+```
+
+### 4. PSQL (Procedural SQL)
+
+#### Stored Procedures
+
+```ebnf
+<create_procedure_statement> ::=
+    CREATE [ OR ALTER ] PROCEDURE <procedure_name>
+    [ ( <parameter_declaration_list> ) ]
+    [ RETURNS ( <parameter_declaration_list> ) ]
+    [ EXTERNAL NAME '<external_module_name>!<routine_name>'
+        ENGINE <engine_name> [ AS <external_body> ] ]  /* Firebird 3.0+ */
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+
+<parameter_declaration> ::=
+    <parameter_name> <data_type> [ { = | DEFAULT } <default_value> ]
+    [ NOT NULL ] [ COLLATE <collation_name> ]
+
+<alter_procedure_statement> ::=
+    ALTER PROCEDURE <procedure_name>
+    [ ( <parameter_declaration_list> ) ]
+    [ RETURNS ( <parameter_declaration_list> ) ]
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+
+<drop_procedure_statement> ::=
+    DROP PROCEDURE [ IF EXISTS ] <procedure_name>
+
+<execute_procedure_statement> ::=
+    EXECUTE PROCEDURE <procedure_name> [ ( <argument_list> ) ]
+    [ RETURNING_VALUES <variable_list> ]
+```
+
+#### Stored Functions
+
+```ebnf
+<create_function_statement> ::=
+    CREATE [ OR ALTER ] FUNCTION <function_name>
+    [ ( <parameter_declaration_list> ) ]
+    RETURNS { <data_type> [ COLLATE <collation_name> ]
+            | [ <data_type> ] TABLE ( <parameter_declaration_list> ) }  /* Firebird 5.0+ table functions */
+    [ DETERMINISTIC ]
+    [ EXTERNAL NAME '<external_module_name>!<routine_name>'
+        ENGINE <engine_name> [ AS <external_body> ] ]  /* Firebird 3.0+ */
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+```
+
+#### Triggers
+
+```ebnf
+<create_trigger_statement> ::=
+    CREATE [ OR ALTER ] TRIGGER <trigger_name>
+    FOR <table_or_view_name>
+    [ ACTIVE | INACTIVE ]
+    { BEFORE | AFTER } { INSERT | UPDATE | DELETE }
+    [ OR { INSERT | UPDATE | DELETE } ]
+    [ POSITION <number> ]
+    [ FOLLOWS <trigger_name> { , <trigger_name> } ]  /* Firebird 4.0+ */
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+
+<database_trigger> ::=
+    CREATE [ OR ALTER ] TRIGGER <trigger_name>
+    [ ACTIVE | INACTIVE ]
+    ON { CONNECT | DISCONNECT | TRANSACTION { START | COMMIT | ROLLBACK } }
+    [ POSITION <number> ]
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+
+<ddl_trigger> ::=
+    CREATE [ OR ALTER ] TRIGGER <trigger_name>
+    [ ACTIVE | INACTIVE ]
+    { BEFORE | AFTER } { <ddl_event> } [ OR { <ddl_event> } ]
+    [ POSITION <number> ]
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+
+<ddl_event> ::=
+    ANY DDL STATEMENT
+  | CREATE { TABLE | PROCEDURE | FUNCTION | TRIGGER | EXCEPTION 
+           | VIEW | DOMAIN | ROLE | SEQUENCE | USER | INDEX | COLLATION
+           | PACKAGE | PACKAGE BODY | MAPPING }
+  | ALTER { TABLE | PROCEDURE | FUNCTION | TRIGGER | EXCEPTION 
+          | VIEW | DOMAIN | ROLE | SEQUENCE | USER | INDEX | COLLATION
+          | CHARACTER SET | PACKAGE | MAPPING }
+  | DROP { TABLE | PROCEDURE | FUNCTION | TRIGGER | EXCEPTION 
+         | VIEW | DOMAIN | ROLE | SEQUENCE | USER | INDEX | COLLATION
+         | PACKAGE | PACKAGE BODY | MAPPING }
+```
+
+#### PSQL Statements
+
+```ebnf
+<psql_statement> ::=
+    <assignment_statement>
+  | <if_statement>
+  | <case_statement>
+  | <while_statement>
+  | <for_statement>
+  | <leave_statement>
+  | <continue_statement>  /* Firebird 3.0+ */
+  | <exit_statement>
+  | <suspend_statement>
+  | <execute_statement>
+  | <execute_block_statement>
+  | <exception_statement>
+  | <return_statement>  /* Firebird 2.5+ */
+  | <cursor_statement>
+  | <sql_statement>
+  | <block_statement>
+
+<declarations> ::=
+    [ DECLARE [ VARIABLE ] <variable_declaration> ; { <variable_declaration> ; } ]
+    [ DECLARE <cursor_declaration> ; { <cursor_declaration> ; } ]
+    [ DECLARE { PROCEDURE | FUNCTION } <subroutine_declaration> ; { <subroutine_declaration> ; } ]  /* Firebird 3.0+ */
+
+<variable_declaration> ::=
+    <variable_name> { <data_type> | TYPE OF <domain_name> | TYPE OF COLUMN <table_name>.<column_name> }
+    [ NOT NULL ] [ COLLATE <collation_name> ]
+    [ { = | DEFAULT } <initial_value> ]
+
+<cursor_declaration> ::=
+    <cursor_name> [ SCROLL ] CURSOR FOR ( <select_statement> )  /* SCROLL: Firebird 3.0+ */
+
+<assignment_statement> ::=
+    <variable> = <expression> ;
+
+<if_statement> ::=
+    IF ( <condition> ) THEN
+        <statement_or_block>
+    [ ELSE
+        <statement_or_block> ]
+
+<case_statement> ::=
+    CASE <expression>
+        WHEN <value> { , <value> } THEN <statement_or_block>
+        { WHEN <value> { , <value> } THEN <statement_or_block> }
+        [ ELSE <statement_or_block> ]
+    END
+  | CASE
+        WHEN <condition> THEN <statement_or_block>
+        { WHEN <condition> THEN <statement_or_block> }
+        [ ELSE <statement_or_block> ]
+    END
+
+<while_statement> ::=
+    [ <label> : ]
+    WHILE ( <condition> ) DO
+        <statement_or_block>
+
+<for_statement> ::=
+    [ <label> : ]
+    FOR <select_statement> [ AS CURSOR <cursor_name> ]
+    DO <statement_or_block>
+  | [ <label> : ]
+    FOR EXECUTE STATEMENT <string_expression> [ ( <parameter_list> ) ]
+        [ ON EXTERNAL [ DATA SOURCE ] <connection_string> 
+          [ AS USER <user> PASSWORD <password> [ ROLE <role> ] ] ]
+        [ WITH { AUTONOMOUS | COMMON } TRANSACTION ]  /* Firebird 2.5+ */
+        [ INTO <variable_list> ]
+    DO <statement_or_block>
+
+<leave_statement> ::=
+    LEAVE [ <label> ] ;
+
+<continue_statement> ::=
+    CONTINUE [ <label> ] ;  /* Firebird 3.0+ */
+
+<exit_statement> ::=
+    EXIT ;
+
+<suspend_statement> ::=
+    SUSPEND ;
+
+<execute_statement> ::=
+    EXECUTE STATEMENT <string_expression> [ ( <parameter_list> ) ]
+    [ ON EXTERNAL [ DATA SOURCE ] <connection_string> 
+      [ AS USER <user> PASSWORD <password> [ ROLE <role> ] ] ]
+    [ WITH { AUTONOMOUS | COMMON } TRANSACTION ]  /* Firebird 2.5+ */
+    [ WITH { CALLER | DEFINER } PRIVILEGES ]  /* Firebird 4.0+ */
+    [ INTO <variable_list> ] ;
+
+<exception_statement> ::=
+    EXCEPTION [ <exception_name> [ <exception_message> | USING ( <parameter_list> ) ] ] ;
+
+<return_statement> ::=
+    RETURN <expression> ;  /* Functions only, Firebird 2.5+ */
+
+<block_statement> ::=
+    BEGIN
+        <statements>
+    [ WHEN { <error_list> | ANY } DO
+        <statement_or_block> ]
+    END
+
+<error_list> ::=
+    <error> { , <error> }
+
+<error> ::=
+    { EXCEPTION <exception_name>
+    | SQLCODE <sqlcode>
+    | SQLSTATE <sqlstate>
+    | GDSCODE <gdscode> }
+```
+
+#### EXECUTE BLOCK
+
+```ebnf
+<execute_block_statement> ::=
+    EXECUTE BLOCK [ ( <parameter_declaration_list> ) ]
+    [ RETURNS ( <parameter_declaration_list> ) ]
+    AS
+    [ <declarations> ]
+    BEGIN
+        <statements>
+    END
+```
+
+### 5. Cursor Operations
+
+```ebnf
+<cursor_statement> ::=
+    <open_cursor>
+  | <fetch_cursor>
+  | <close_cursor>
+
+<open_cursor> ::=
+    OPEN <cursor_name> ;
+
+<fetch_cursor> ::=
+    FETCH [ <fetch_direction> ] [ FROM ] <cursor_name>
+    INTO <variable_list> ;
+
+<fetch_direction> ::=
+    NEXT | PRIOR | FIRST | LAST 
+  | ABSOLUTE <value> | RELATIVE <value>  /* For SCROLL cursors */
+
+<close_cursor> ::=
+    CLOSE <cursor_name> ;
+```
+
+### 6. Packages (Firebird 3.0+)
+
+```ebnf
+<create_package_header> ::=
+    CREATE [ OR ALTER ] PACKAGE <package_name>
+    [ SQL SECURITY { DEFINER | INVOKER } ]  /* Firebird 4.0+ */
+    AS
+    BEGIN
+        [ <package_item> ; { <package_item> ; } ]
+    END
+
+<create_package_body> ::=
+    CREATE [ OR ALTER ] PACKAGE BODY <package_name>
+    AS
+    BEGIN
+        [ <package_body_item> ; { <package_body_item> ; } ]
+        [ <initialization_block> ; ]
+    END
+
+<package_item> ::=
+    <function_declaration>
+  | <procedure_declaration>
+  | <variable_declaration>
+  | <cursor_declaration>
+  | <type_declaration>
+
+<package_body_item> ::=
+    <function_implementation>
+  | <procedure_implementation>
+  | <variable_declaration>
+  | <cursor_declaration>
+  | <type_declaration>
+
+<initialization_block> ::=
+    BEGIN
+        <statements>
+    END
+```
+
+### 7. User-Defined Functions (UDF) - Legacy
+
+```ebnf
+<declare_external_function> ::=
+    DECLARE EXTERNAL FUNCTION <function_name>
+    [ <parameter_type> { , <parameter_type> } ]
+    RETURNS { <parameter_type> [ BY VALUE ] | PARAMETER <position> }
+    [ FREE_IT ]
+    ENTRY_POINT '<entry_point>'
+    MODULE_NAME '<module_name>'
+```
+
+### 8. Window Functions (Firebird 3.0+)
+
+```ebnf
+<window_function> ::=
+    <window_function_name> ( [ <expression_list> ] ) OVER <window_specification>
+
+<window_specification> ::=
+    ( [ <partition_clause> ] [ <order_clause> ] [ <frame_clause> ] )
+  | <window_name>
+
+<window_definition> ::=
+    <window_name> AS ( <window_specification> )
+
+<partition_clause> ::=
+    PARTITION BY <expression_list>
+
+<order_clause> ::=
+    ORDER BY <order_item_list>
+
+<frame_clause> ::=
+    { RANGE | ROWS } { <frame_start> | BETWEEN <frame_start> AND <frame_end> }
+    [ EXCLUDE { CURRENT ROW | GROUP | TIES | NO OTHERS } ]  /* Firebird 4.0+ */
+
+<frame_start> ::=
+    UNBOUNDED PRECEDING
+  | <expression> PRECEDING
+  | CURRENT ROW
+  | <expression> FOLLOWING
+
+<frame_end> ::=
+    <expression> PRECEDING
+  | CURRENT ROW
+  | <expression> FOLLOWING
+  | UNBOUNDED FOLLOWING
+
+<window_function_name> ::=
+    ROW_NUMBER | RANK | DENSE_RANK | PERCENT_RANK | CUME_DIST
+  | LAG | LEAD | FIRST_VALUE | LAST_VALUE | NTH_VALUE
+  | NTILE
+```
+
+### 9. Common Table Expressions (CTE)
+
+```ebnf
+<with_clause> ::=
+    WITH [ RECURSIVE ] <cte_definition> { , <cte_definition> }
+
+<cte_definition> ::=
+    <cte_name> [ ( <column_list> ) ] AS ( <select_statement> )
+```
+
+### 10. Transaction Control
+
+```ebnf
+<transaction_statement> ::=
+    SET TRANSACTION [ <transaction_option> { <transaction_option> } ]
+  | COMMIT [ WORK ] [ RETAIN [ SNAPSHOT ] ]
+  | ROLLBACK [ WORK ] [ TO [ SAVEPOINT ] <savepoint_name> ]
+    [ RETAIN [ SNAPSHOT ] ]
+  | SAVEPOINT <savepoint_name>
+  | RELEASE SAVEPOINT <savepoint_name> [ ONLY ]
+
+<transaction_option> ::=
+    READ { WRITE | ONLY }
+  | [ ISOLATION LEVEL ] { SNAPSHOT [ TABLE STABILITY ] 
+                        | READ { COMMITTED [ { NO | } RECORD_VERSION ] | UNCOMMITTED } }
+  | [ NO ] WAIT
+  | [ LOCK TIMEOUT <seconds> ]
+  | NO AUTO UNDO  /* Firebird 3.0+ */
+  | RESTART REQUESTS  /* Firebird 4.0+ */
+  | IGNORE LIMBO
+  | AUTOCOMMIT
+  | RESERVING <table_list> FOR <reservation_specification>
+
+<reservation_specification> ::=
+    [ SHARED | PROTECTED ] { READ | WRITE }
+```
+
+### 11. Security and Access Control
+
+```ebnf
+<create_role> ::=
+    CREATE ROLE <role_name>
+    [ SET SYSTEM PRIVILEGES TO <system_privilege_list> ]  /* Firebird 4.0+ */
+
+<grant_statement> ::=
+    GRANT { <privilege_list> ON [ <object_type> ] <object_name>
+          | <role_list>
+          | <system_privilege_list> }  /* Firebird 4.0+ */
+    TO { <grantee_list> | <role_list> }
+    [ WITH { GRANT | ADMIN } OPTION ]
+    [ GRANTED BY { CURRENT_USER | CURRENT_ROLE } ]
+
+<privilege> ::=
+    ALL [ PRIVILEGES ]
+  | SELECT | INSERT | UPDATE [ ( <column_list> ) ] | DELETE
+  | REFERENCES [ ( <column_list> ) ]
+  | EXECUTE | USAGE | CREATE | ALTER ANY | DROP ANY
+
+<system_privilege> ::=
+    USER_MANAGEMENT | READ_RAW_PAGES | CREATE_USER_TYPES
+  | USE_NBACKUP_UTILITY | CHANGE_SHUTDOWN_MODE | TRACE_ANY_ATTACHMENT
+  | MONITOR_ANY_ATTACHMENT | ACCESS_SHUTDOWN_DATABASE
+  | CREATE_DATABASE | DROP_DATABASE | USE_GBAK_UTILITY
+  | USE_GSTAT_UTILITY | USE_GFIX_UTILITY
+  | IGNORE_DB_TRIGGERS | CHANGE_HEADER_SETTINGS
+  | SELECT_ANY_OBJECT_IN_DATABASE  /* Firebird 4.0+ */
+  | ACCESS_ANY_OBJECT_IN_DATABASE  /* Firebird 4.0+ */
+  | MODIFY_ANY_OBJECT_IN_DATABASE  /* Firebird 4.0+ */
+  | CHANGE_MAPPING_RULES | GRANT_REVOKE_ON_ANY_OBJECT
+  | GRANT_REVOKE_ANY_DDL_RIGHT | CREATE_PRIVILEGED_ROLES
+  
+<revoke_statement> ::=
+    REVOKE [ { GRANT | ADMIN } OPTION FOR ]
+    { <privilege_list> ON [ <object_type> ] <object_name>
+    | <role_list>
+    | <system_privilege_list> }  /* Firebird 4.0+ */
+    FROM { <grantee_list> | <role_list> }
+    [ GRANTED BY { CURRENT_USER | CURRENT_ROLE } ]
+```
+
+### 12. Mapping (Firebird 3.0+)
+
+```ebnf
+<create_mapping> ::=
+    CREATE [ OR ALTER ] [ GLOBAL ] MAPPING <mapping_name>
+    USING { PLUGIN <plugin_name> [ IN <database_name> ]
+          | ANY PLUGIN [ IN <database_name> | SERVERWIDE ]
+          | MAPPING [ IN <database_name> ] | '*' [ IN <database_name> ] }
+    FROM { ANY <object_type> | <object_type> <object_name> }
+    TO { USER | ROLE } [ <target_name> ]
+
+<alter_mapping> ::=
+    ALTER [ GLOBAL ] MAPPING <mapping_name>
+    USING { PLUGIN <plugin_name> [ IN <database_name> ]
+          | ANY PLUGIN [ IN <database_name> | SERVERWIDE ]
+          | MAPPING [ IN <database_name> ] | '*' [ IN <database_name> ] }
+    FROM { ANY <object_type> | <object_type> <object_name> }
+    TO { USER | ROLE } [ <target_name> ]
+
+<drop_mapping> ::=
+    DROP [ GLOBAL ] MAPPING <mapping_name>
+```
+
+### 13. Management Statements
+
+```ebnf
+<set_statistics> ::=
+    SET STATISTICS INDEX <index_name>
+
+<set_generator> ::=
+    SET GENERATOR <generator_name> TO <value>
+
+<alter_sequence> ::=
+    ALTER SEQUENCE <sequence_name> { RESTART [ WITH <value> ] | INCREMENT [ BY ] <value> }
+
+<comment_statement> ::=
+    COMMENT ON { DATABASE | <object_type> <object_name> | COLUMN <table_name>.<column_name> 
+               | PARAMETER <procedure_name>.<parameter_name> }
+    IS { '<text>' | NULL }
+
+<create_collation> ::=
+    CREATE COLLATION <collation_name>
+    FOR <charset_name>
+    [ FROM { <base_collation> | EXTERNAL ( '<collation_name>' ) } ]
+    [ NO PAD | PAD SPACE ]
+    [ CASE { SENSITIVE | INSENSITIVE } ]
+    [ ACCENT { SENSITIVE | INSENSITIVE } ]
+    [ ATTRIBUTES '<attributes>' ]
+
+<alter_character_set> ::=
+    ALTER CHARACTER SET <charset_name>
+    SET DEFAULT COLLATION <collation_name>
+```
+
+### 14. Context Variables
+
+```ebnf
+<context_variable> ::=
+    CURRENT_CONNECTION | CURRENT_TRANSACTION
+  | CURRENT_DATE | CURRENT_TIME | CURRENT_TIMESTAMP
+  | LOCALTIME | LOCALTIMESTAMP  /* Firebird 2.5+ */
+  | CURRENT_USER | CURRENT_ROLE
+  | ROW_COUNT
+  | SQLCODE | GDSCODE | SQLSTATE
+  | INSERTING | UPDATING | DELETING  /* Triggers only */
+  | TODAY | NOW | TOMORROW | YESTERDAY
+```
+
+### 15. Built-in Functions
+
+```ebnf
+<function_call> ::=
+    <function_name> ( [ <argument_list> ] )
+
+<aggregate_function> ::=
+    COUNT ( { * | [ { ALL | DISTINCT } ] <expression> } )
+  | SUM ( [ { ALL | DISTINCT } ] <expression> )
+  | AVG ( [ { ALL | DISTINCT } ] <expression> )
+  | MIN ( [ { ALL | DISTINCT } ] <expression> )
+  | MAX ( [ { ALL | DISTINCT } ] <expression> )
+  | LIST ( [ { ALL | DISTINCT } ] <expression> [ , <delimiter> ] )
+  | STDDEV_POP ( <expression> )  /* Firebird 2.1+ */
+  | STDDEV_SAMP ( <expression> )  /* Firebird 2.1+ */
+  | VAR_POP ( <expression> )  /* Firebird 2.1+ */
+  | VAR_SAMP ( <expression> )  /* Firebird 2.1+ */
+  | COVAR_POP ( <expression1> , <expression2> )  /* Firebird 2.1+ */
+  | COVAR_SAMP ( <expression1> , <expression2> )  /* Firebird 2.1+ */
+  | CORR ( <expression1> , <expression2> )  /* Firebird 2.1+ */
+  | REGR_* ( <expression1> , <expression2> )  /* Firebird 4.0+ */
+  | ANY_VALUE ( <expression> )  /* Firebird 5.0+ */
+
+<string_function> ::=
+    ASCII_CHAR ( <code> )
+  | ASCII_VAL ( <string> )
+  | BIT_LENGTH ( <string> )
+  | CHAR_LENGTH ( <string> ) | CHARACTER_LENGTH ( <string> )
+  | CONTAINING ( <substring> )  /* Predicate, not function */
+  | LEFT ( <string> , <length> )
+  | LOWER ( <string> )
+  | LPAD ( <string> , <length> [ , <pad_string> ] )
+  | LTRIM ( <string> [ , <trim_string> ] )  /* Firebird 4.0+ */
+  | OCTET_LENGTH ( <string> )
+  | OVERLAY ( <string> PLACING <substring> FROM <position> [ FOR <length> ] )
+  | POSITION ( <substring> IN <string> )
+  | REPLACE ( <string> , <search> , <replace> )
+  | REVERSE ( <string> )
+  | RIGHT ( <string> , <length> )
+  | RPAD ( <string> , <length> [ , <pad_string> ] )
+  | RTRIM ( <string> [ , <trim_string> ] )  /* Firebird 4.0+ */
+  | STARTING [ WITH ] ( <substring> )  /* Predicate, not function */
+  | SUBSTRING ( <string> FROM <position> [ FOR <length> ] )
+  | TRIM ( [ [ { LEADING | TRAILING | BOTH } ] [ <trim_string> ] FROM ] <string> )
+  | UPPER ( <string> )
+
+<datetime_function> ::=
+    DATEADD ( <date_part> , <value> , <datetime> )
+  | DATEDIFF ( <date_part> , <datetime1> , <datetime2> )
+  | EXTRACT ( <date_part> FROM <datetime> )
+  | FIRST_DAY ( OF { YEAR | QUARTER | MONTH | WEEK } FROM <date> )  /* Firebird 4.0+ */
+  | LAST_DAY ( OF { YEAR | QUARTER | MONTH | WEEK } FROM <date> )  /* Firebird 4.0+ */
+
+<date_part> ::=
+    YEAR | QUARTER | MONTH | WEEK | DAY | WEEKDAY | YEARDAY
+  | HOUR | MINUTE | SECOND | MILLISECOND
+  | TIMEZONE_HOUR | TIMEZONE_MINUTE  /* Firebird 4.0+ */
+
+<math_function> ::=
+    ABS ( <value> )
+  | ACOS ( <value> )
+  | ACOSH ( <value> )  /* Firebird 3.0+ */
+  | ASIN ( <value> )
+  | ASINH ( <value> )  /* Firebird 3.0+ */
+  | ATAN ( <value> )
+  | ATAN2 ( <y> , <x> )
+  | ATANH ( <value> )  /* Firebird 3.0+ */
+  | CEIL ( <value> ) | CEILING ( <value> )
+  | COS ( <value> )
+  | COSH ( <value> )
+  | COT ( <value> )
+  | EXP ( <value> )
+  | FLOOR ( <value> )
+  | LN ( <value> )
+  | LOG ( <base> , <value> )
+  | LOG10 ( <value> )
+  | MOD ( <value1> , <value2> )
+  | PI ( )
+  | POWER ( <value> , <exponent> )
+  | RAND ( )
+  | ROUND ( <value> [ , <scale> ] )
+  | SIGN ( <value> )
+  | SIN ( <value> )
+  | SINH ( <value> )
+  | SQRT ( <value> )
+  | TAN ( <value> )
+  | TANH ( <value> )
+  | TRUNC ( <value> [ , <scale> ] )
+
+<conversion_function> ::=
+    CAST ( <expression> AS <data_type> )
+  | DECODE ( <expression> , <search> , <result> { , <search> , <result> } [ , <default> ] )
+  | IIF ( <condition> , <true_value> , <false_value> )
+  | NULLIF ( <expression1> , <expression2> )
+  | COALESCE ( <expression> { , <expression> } )
+
+<blob_function> ::=
+    BLOB_APPEND ( <blob> [ , <value> { , <value> } ] )  /* Firebird 3.0+ */
+
+<uuid_function> ::=
+    GEN_UUID ( )
+  | UUID_TO_CHAR ( <uuid> )  /* Firebird 2.5+ */
+  | CHAR_TO_UUID ( <string> )  /* Firebird 2.5+ */
+
+<hash_function> ::=
+    HASH ( <value> [ USING <algorithm> ] )  /* Firebird 2.1+ */
+  | CRYPT_HASH ( <value> USING <algorithm> )  /* Firebird 4.0+ */
+
+<algorithm> ::= MD5 | SHA1 | SHA256 | SHA512 | SHA3_224 | SHA3_256 | SHA3_384 | SHA3_512
+
+<encrypt_decrypt> ::=
+    ENCRYPT ( <value> USING <algorithm> KEY <key> [ IV <iv> ] [ <options> ] )  /* Firebird 3.0+ */
+  | DECRYPT ( <value> USING <algorithm> KEY <key> [ IV <iv> ] [ <options> ] )  /* Firebird 3.0+ */
+  | RSA_ENCRYPT ( <value> KEY <key> [ LPARAM <tag> ] [ HASH <hash_algorithm> ] )  /* Firebird 4.0+ */
+  | RSA_DECRYPT ( <value> KEY <key> [ LPARAM <tag> ] [ HASH <hash_algorithm> ] )  /* Firebird 4.0+ */
+  | RSA_SIGN_HASH ( <value> KEY <key> [ HASH <hash_algorithm> ] [ SALTLENGTH <length> ] )  /* Firebird 4.0+ */
+  | RSA_VERIFY_HASH ( <value> SIGNATURE <signature> KEY <key> [ HASH <hash_algorithm> ] [ SALTLENGTH <length> ] )  /* Firebird 4.0+ */
+
+<bit_function> ::=
+    BIN_AND ( <value1> , <value2> )
+  | BIN_OR ( <value1> , <value2> )
+  | BIN_XOR ( <value1> , <value2> )
+  | BIN_NOT ( <value> )
+  | BIN_SHL ( <value> , <positions> )
+  | BIN_SHR ( <value> , <positions> )
+
+<compare_function> ::=
+    MINVALUE ( <value> { , <value> } )  /* Firebird 2.1+ */
+  | MAXVALUE ( <value> { , <value> } )  /* Firebird 2.1+ */
+  | COMPARE_DECFLOAT ( <value1> , <value2> )  /* Firebird 4.0+ */
+  | TOTALORDER ( <value1> , <value2> )  /* Firebird 4.0+ */
+```
+
+### 16. Operators
+
+```ebnf
+<operator> ::=
+    -- Arithmetic
+    + | - | * | / | 
+
+    -- Comparison
+    = | <> | != | ~= | ^= | < | <= | > | >= 
+  | IS [ NOT ] { NULL | TRUE | FALSE | UNKNOWN }
+  | IS [ NOT ] DISTINCT FROM
+
+    -- Logical
+    AND | OR | NOT
+
+    -- String
+    || | COLLATE
+
+    -- Set membership
+    [ NOT ] IN
+  | [ NOT ] EXISTS
+  | { ALL | SOME | ANY }
+  | SINGULAR
+
+    -- Pattern matching
+    [ NOT ] LIKE [ ESCAPE <escape_char> ]
+  | [ NOT ] SIMILAR TO [ ESCAPE <escape_char> ]
+  | [ NOT ] CONTAINING
+  | [ NOT ] STARTING [ WITH ]
+
+    -- Range
+    [ NOT ] BETWEEN ... AND ...
+```
+
+### 17. Query Hints and Optimization
+
+```ebnf
+<plan_clause> ::=
+    PLAN <plan_expression>
+
+<plan_expression> ::=
+    ( <plan_item> { , <plan_item> } )
+  | <plan_item>
+
+<plan_item> ::=
+    [ <table_alias> ] { NATURAL 
+                      | INDEX ( <index_name> { , <index_name> } ) 
+                      | ORDER <index_name> }
+  | JOIN ( <plan_item> , <plan_item> { , <plan_item> } )
+  | [ SORT ] MERGE ( <plan_item> { , <plan_item> } )
+  | HASH ( <plan_item> { , <plan_item> } )  /* Firebird 3.0+ */
+  | <derived_table_alias> ( <plan_expression> )
+```
+
+### 18. External Tables
+
+```ebnf
+<external_table_clause> ::=
+    EXTERNAL [ FILE ] '<file_path>'
+```
+
+### 19. Monitoring Tables
+
+```ebnf
+<monitoring_tables> ::=
+    MON$ATTACHMENTS | MON$CALL_STACK | MON$CONTEXT_VARIABLES
+  | MON$DATABASE | MON$IO_STATS | MON$MEMORY_USAGE
+  | MON$RECORD_STATS | MON$STATEMENTS | MON$TABLE_STATS
+  | MON$TRANSACTIONS | MON$COMPILED_STATEMENTS  /* Firebird 5.0+ */
+  | MON$KEYWORDS  /* Firebird 5.0+ */
+```
+
+### 20. Special Syntax Elements
+
+```ebnf
+<special_values> ::=
+    TRUE | FALSE | UNKNOWN  /* Boolean literals, Firebird 3.0+ */
+  | NULL
+
+<named_argument> ::=
+    <parameter_name> => <expression>  /* Firebird 5.0+ */
+
+<default_argument> ::=
+    DEFAULT  /* For procedure/function calls with default parameters */
+
+<returning_clause> ::=
+    RETURNING <column_list> [ INTO <variable_list> ]
+
+<cursor_attribute> ::=
+    <cursor_name> % { ISOPEN | FOUND | NOTFOUND | ROWCOUNT }  /* PSQL */
+
+<qualified_name> ::=
+    [ <schema_name> . ] <object_name>  /* Schema support: planned future */
+
+<delimited_identifier> ::=
+    " <identifier_body> "
+
+<string_literal> ::=
+    ' <string_body> '
+  | q'<delimiter> <string_body> <delimiter>'  /* Firebird 3.0+ */
+
+<binary_literal> ::=
+    x'<hex_digits>'  /* Firebird 2.5+ */
+  | 0x<hex_digits>  /* Firebird 4.0+ */
+
+<introducer> ::=
+    _<charset_name>
+
+<escape_sequence> ::=
+    '' | "" | <escape_char><special_char>
+```
+
+## Usage Notes
+
+1. **Dialect Settings**: Firebird supports dialect 1 and 3, affecting identifier case sensitivity and other behaviors
+2. **Identifier Length**: Maximum 63 characters (31 in dialect 1)
+3. **Case Sensitivity**: 
+   - Unquoted identifiers are case-insensitive, stored in uppercase
+   - Quoted identifiers preserve case
+4. **String Literals**: Use single quotes; double quotes for identifiers
+5. **Comments**: 
+   - Single line: `--` or `//` (Firebird 5.0+)
+   - Multi-line: `/* ... */`
+6. **Statement Terminators**: `;` in SQL, can be changed in ISQL with `SET TERM`
+7. **NULL Handling**: Firebird follows SQL standard NULL semantics
+8. **Arrays**: Multi-dimensional arrays supported but with limitations
+9. **Contexts**: Firebird supports multiple contexts (USER_SESSION, USER_TRANSACTION, SYSTEM)
+10. **Character Sets**: Extensive support including UTF8, must be specified correctly
+
+This comprehensive grammar covers Firebird SQL and PSQL from version 2.5 through 5.0, providing a complete foundation for implementing a Firebird SQL parser.

--- a/references/sql_dialects/mysql_mariadb_bnf_ebnf.md
+++ b/references/sql_dialects/mysql_mariadb_bnf_ebnf.md
@@ -1,0 +1,1103 @@
+# MySQL/MariaDB SQL Variations BNF/EBNF Grammar
+
+## Overview
+This document provides a comprehensive BNF/EBNF grammar specification for MySQL and MariaDB SQL variations and dialect-specific features. While MySQL and MariaDB share a common heritage, MariaDB has diverged with additional features. This grammar covers both, with annotations for version-specific features.
+
+## Notation
+- `::=` defines a production rule
+- `|` indicates alternatives
+- `[ ]` indicates optional elements
+- `{ }` indicates zero or more repetitions
+- `( )` groups elements
+- `< >` denotes non-terminals
+- Terminal symbols are in UPPERCASE or quoted
+- `/*MySQL*/` indicates MySQL-specific features
+- `/*MariaDB*/` indicates MariaDB-specific features
+
+## Core Grammar Extensions
+
+### 1. Data Types
+
+```ebnf
+<mysql_data_type> ::=
+    <numeric_type>
+  | <string_type>
+  | <date_time_type>
+  | <json_type>
+  | <spatial_type>
+  | <binary_type>
+
+<numeric_type> ::=
+    BIT [ ( <length> ) ]
+  | TINYINT [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | SMALLINT [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | MEDIUMINT [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | INT [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | INTEGER [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | BIGINT [ ( <display_width> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | DECIMAL [ ( <precision> [ , <scale> ] ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | DEC [ ( <precision> [ , <scale> ] ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | NUMERIC [ ( <precision> [ , <scale> ] ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | FIXED [ ( <precision> [ , <scale> ] ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | FLOAT [ ( <precision> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | DOUBLE [ PRECISION ] [ ( <precision> , <scale> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | REAL [ ( <precision> , <scale> ) ] [ UNSIGNED ] [ ZEROFILL ]
+  | BOOL | BOOLEAN
+
+<string_type> ::=
+    CHAR [ ( <length> ) ] [ BINARY ] [ <charset_clause> ] [ <collate_clause> ]
+  | VARCHAR ( <length> ) [ BINARY ] [ <charset_clause> ] [ <collate_clause> ]
+  | BINARY [ ( <length> ) ]
+  | VARBINARY ( <length> )
+  | TINYBLOB | TINYTEXT [ <charset_clause> ] [ <collate_clause> ]
+  | BLOB [ ( <length> ) ] | TEXT [ ( <length> ) ] [ <charset_clause> ] [ <collate_clause> ]
+  | MEDIUMBLOB | MEDIUMTEXT [ <charset_clause> ] [ <collate_clause> ]
+  | LONGBLOB | LONGTEXT [ <charset_clause> ] [ <collate_clause> ]
+  | ENUM ( <value_list> ) [ <charset_clause> ] [ <collate_clause> ]
+  | SET ( <value_list> ) [ <charset_clause> ] [ <collate_clause> ]
+
+<date_time_type> ::=
+    DATE
+  | TIME [ ( <fsp> ) ]
+  | DATETIME [ ( <fsp> ) ]
+  | TIMESTAMP [ ( <fsp> ) ]
+  | YEAR [ ( 4 ) ]
+
+<json_type> ::= JSON  /*MySQL 5.7+, MariaDB 10.2+*/
+
+<spatial_type> ::=
+    GEOMETRY
+  | POINT
+  | LINESTRING
+  | POLYGON
+  | MULTIPOINT
+  | MULTILINESTRING
+  | MULTIPOLYGON
+  | GEOMETRYCOLLECTION
+
+<charset_clause> ::= CHARACTER SET <charset_name>
+<collate_clause> ::= COLLATE <collation_name>
+```
+
+### 2. DDL Extensions
+
+#### CREATE TABLE Extensions
+
+```ebnf
+<create_table_statement> ::=
+    CREATE [ TEMPORARY ] TABLE [ IF NOT EXISTS ] <table_name>
+    { ( <create_definition_list> ) [ <table_options> ] [ <partition_options> ]
+    | LIKE <old_table_name>
+    | ( LIKE <old_table_name> )
+    | [ AS ] <select_statement> }
+
+<create_definition> ::=
+    <column_definition>
+  | <index_definition>
+  | <constraint_definition>
+  | <check_constraint>  /*MySQL 8.0.16+, MariaDB 10.2+*/
+  | <period_definition>  /*MariaDB 10.3+*/
+
+<column_definition> ::=
+    <column_name> <column_type> [ <column_attribute> { <column_attribute> } ]
+
+<column_attribute> ::=
+    NOT NULL | NULL
+  | DEFAULT { <literal> | ( <expression> ) | <function_call> }
+  | VISIBLE | INVISIBLE  /*MySQL 8.0.23+, MariaDB 10.3+*/
+  | AUTO_INCREMENT
+  | UNIQUE [ KEY ]
+  | [ PRIMARY ] KEY
+  | COMMENT '<string>'
+  | COLLATE <collation_name>
+  | COLUMN_FORMAT { FIXED | DYNAMIC | DEFAULT }
+  | STORAGE { DISK | MEMORY | DEFAULT }
+  | <reference_definition>
+  | CHECK ( <expression> )  /*MySQL 8.0.16+, MariaDB 10.2+*/
+  | GENERATED ALWAYS AS ( <expression> ) { VIRTUAL | STORED | PERSISTENT }
+    /*MySQL 5.7+, MariaDB 5.2+ (PERSISTENT is MariaDB)*/
+  | ON UPDATE <current_timestamp_function>
+  | COMPRESSED [ = { ZLIB | LZ4 | LZO | SNAPPY } ]  /*MariaDB 10.1+*/
+  | WITH SYSTEM VERSIONING  /*MariaDB 10.3+*/
+
+<index_definition> ::=
+    { INDEX | KEY } [ <index_name> ] [ <index_type> ] ( <key_part_list> ) [ <index_option> { <index_option> } ]
+  | FULLTEXT [ INDEX | KEY ] [ <index_name> ] ( <key_part_list> ) [ <index_option> { <index_option> } ]
+  | SPATIAL [ INDEX | KEY ] [ <index_name> ] ( <key_part_list> ) [ <index_option> { <index_option> } ]
+  | [ CONSTRAINT [ <symbol> ] ] PRIMARY KEY [ <index_type> ] ( <key_part_list> ) [ <index_option> { <index_option> } ]
+  | [ CONSTRAINT [ <symbol> ] ] UNIQUE [ INDEX | KEY ] [ <index_name> ] [ <index_type> ] ( <key_part_list> ) [ <index_option> { <index_option> } ]
+  | [ CONSTRAINT [ <symbol> ] ] FOREIGN KEY [ <index_name> ] ( <key_part_list> ) <reference_definition>
+
+<key_part> ::=
+    <column_name> [ ( <length> ) ] [ ASC | DESC ]
+  | ( <expression> ) [ ASC | DESC ]  /*MySQL 8.0+*/
+
+<index_type> ::= USING { BTREE | HASH | RTREE }
+
+<index_option> ::=
+    KEY_BLOCK_SIZE [ = ] <value>
+  | <index_type>
+  | WITH PARSER <parser_name>
+  | COMMENT '<string>'
+  | VISIBLE | INVISIBLE  /*MySQL 8.0+*/
+  | ENGINE_ATTRIBUTE [ = ] '<string>'  /*MySQL 8.0.21+*/
+  | SECONDARY_ENGINE_ATTRIBUTE [ = ] '<string>'  /*MySQL 8.0.21+*/
+  | CLUSTERING [ = ] { YES | NO }  /*MariaDB 10.3+*/
+  | IGNORED  /*MariaDB 10.6+*/
+
+<reference_definition> ::=
+    REFERENCES <table_name> ( <key_part_list> )
+    [ MATCH { FULL | PARTIAL | SIMPLE } ]
+    [ ON DELETE <reference_option> ]
+    [ ON UPDATE <reference_option> ]
+
+<reference_option> ::=
+    RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT
+
+<table_options> ::=
+    <table_option> [ [ , ] <table_option> ] ...
+
+<table_option> ::=
+    [ DEFAULT ] { CHARACTER SET | CHARSET } [ = ] <charset_name>
+  | [ DEFAULT ] COLLATE [ = ] <collation_name>
+  | ENGINE [ = ] <engine_name>
+  | AUTO_INCREMENT [ = ] <value>
+  | AVG_ROW_LENGTH [ = ] <value>
+  | CHECKSUM [ = ] { 0 | 1 }
+  | COMMENT [ = ] '<string>'
+  | COMPRESSION [ = ] { 'ZLIB' | 'LZ4' | 'NONE' }
+  | CONNECTION [ = ] '<connect_string>'
+  | DATA DIRECTORY [ = ] '<absolute_path>'
+  | INDEX DIRECTORY [ = ] '<absolute_path>'
+  | DELAY_KEY_WRITE [ = ] { 0 | 1 }
+  | ENCRYPTION [ = ] { 'Y' | 'N' }  /*MySQL 5.7.11+, MariaDB 10.1+*/
+  | INSERT_METHOD [ = ] { NO | FIRST | LAST }
+  | KEY_BLOCK_SIZE [ = ] <value>
+  | MAX_ROWS [ = ] <value>
+  | MIN_ROWS [ = ] <value>
+  | PACK_KEYS [ = ] { 0 | 1 | DEFAULT }
+  | PASSWORD [ = ] '<string>'
+  | ROW_FORMAT [ = ] { DEFAULT | DYNAMIC | FIXED | COMPRESSED | REDUNDANT | COMPACT }
+  | PAGE_COMPRESSED [ = ] { 0 | 1 }  /*MariaDB 10.1+*/
+  | PAGE_COMPRESSION_LEVEL [ = ] <value>  /*MariaDB 10.1+*/
+  | SEQUENCE [ = ] { 0 | 1 }  /*MariaDB 10.3+*/
+  | STATS_AUTO_RECALC [ = ] { DEFAULT | 0 | 1 }
+  | STATS_PERSISTENT [ = ] { DEFAULT | 0 | 1 }
+  | STATS_SAMPLE_PAGES [ = ] <value>
+  | TABLESPACE <tablespace_name> [ STORAGE { DISK | MEMORY } ]
+  | UNION [ = ] ( <table_list> )
+  | WITH SYSTEM VERSIONING  /*MariaDB 10.3+*/
+```
+
+#### CREATE INDEX Extensions
+
+```ebnf
+<create_index_statement> ::=
+    CREATE [ UNIQUE | FULLTEXT | SPATIAL ] INDEX <index_name>
+    [ <index_type> ]
+    ON <table_name> ( <key_part_list> )
+    [ <index_option> { <index_option> } ]
+    [ <algorithm_option> ] [ <lock_option> ]
+
+<algorithm_option> ::= ALGORITHM [ = ] { DEFAULT | INPLACE | COPY | INSTANT }
+    /*INSTANT added in MySQL 8.0.12, MariaDB 10.3.7*/
+
+<lock_option> ::= LOCK [ = ] { DEFAULT | NONE | SHARED | EXCLUSIVE }
+```
+
+### 3. DML Extensions
+
+#### INSERT Extensions
+
+```ebnf
+<insert_statement> ::=
+    INSERT [ LOW_PRIORITY | DELAYED | HIGH_PRIORITY ] [ IGNORE ]
+    [ INTO ] <table_name>
+    [ PARTITION ( <partition_list> ) ]
+    [ ( <column_list> ) ]
+    { VALUES <value_list> { , <value_list> }
+    | VALUE <value_list> { , <value_list> }
+    | <select_statement>
+    | SET <assignment_list>
+    | TABLE <table_name>  /*MySQL 8.0.19+*/ }
+    [ ON DUPLICATE KEY UPDATE <assignment_list> ]
+    [ RETURNING <select_expr_list> ]  /*MariaDB 10.5+*/
+
+<assignment> ::=
+    <column_name> = { <expression> | VALUES ( <column_name> ) | DEFAULT }
+
+<value_list> ::=
+    ( { <expression> | DEFAULT } { , { <expression> | DEFAULT } } )
+  | ROW ( { <expression> | DEFAULT } { , { <expression> | DEFAULT } } )
+```
+
+#### UPDATE Extensions
+
+```ebnf
+<update_statement> ::=
+    UPDATE [ LOW_PRIORITY ] [ IGNORE ] <table_reference_list>
+    SET <assignment_list>
+    [ WHERE <where_condition> ]
+    [ ORDER BY <order_list> ]
+    [ LIMIT <row_count> ]
+    [ RETURNING <select_expr_list> ]  /*MariaDB 10.5+*/
+
+<table_reference> ::=
+    <table_name> [ [ AS ] <alias> ]
+    [ USE INDEX ( <index_list> ) ]
+    [ IGNORE INDEX ( <index_list> ) ]
+    [ FORCE INDEX ( <index_list> ) ]
+```
+
+#### DELETE Extensions
+
+```ebnf
+<delete_statement> ::=
+    DELETE [ LOW_PRIORITY ] [ QUICK ] [ IGNORE ]
+    { FROM <table_name> [ [ AS ] <alias> ]
+        [ PARTITION ( <partition_list> ) ]
+        [ WHERE <where_condition> ]
+        [ ORDER BY <order_list> ]
+        [ LIMIT <row_count> ]
+        [ RETURNING <select_expr_list> ]  /*MariaDB 10.5+*/
+    | <table_list> FROM <table_reference_list>
+        [ WHERE <where_condition> ]
+    | FROM <table_list> USING <table_reference_list>
+        [ WHERE <where_condition> ] }
+```
+
+#### REPLACE Statement
+
+```ebnf
+<replace_statement> ::=
+    REPLACE [ LOW_PRIORITY | DELAYED ]
+    [ INTO ] <table_name>
+    [ PARTITION ( <partition_list> ) ]
+    [ ( <column_list> ) ]
+    { VALUES <value_list> { , <value_list> }
+    | VALUE <value_list> { , <value_list> }
+    | <select_statement>
+    | SET <assignment_list>
+    | TABLE <table_name> }  /*MySQL 8.0.19+*/
+```
+
+### 4. Query Extensions
+
+#### SELECT Extensions
+
+```ebnf
+<select_statement> ::=
+    [ <with_clause> ]  /*MySQL 8.0+, MariaDB 10.2.1+*/
+    SELECT
+    [ ALL | DISTINCT | DISTINCTROW ]
+    [ HIGH_PRIORITY ]
+    [ STRAIGHT_JOIN ]
+    [ SQL_SMALL_RESULT ] [ SQL_BIG_RESULT ] [ SQL_BUFFER_RESULT ]
+    [ SQL_NO_CACHE ] [ SQL_CALC_FOUND_ROWS ]  /*Deprecated in MySQL 8.0.17*/
+    <select_expr_list>
+    [ FROM <table_reference_list>
+        [ WHERE <where_condition> ]
+        [ GROUP BY <group_by_list> [ WITH ROLLUP ] ]
+        [ HAVING <having_condition> ]
+        [ WINDOW <window_definition_list> ] ]  /*MySQL 8.0+, MariaDB 10.2+*/
+    [ ORDER BY <order_list> ]
+    [ LIMIT { <row_count> | <offset> , <row_count> | <row_count> OFFSET <offset> } ]
+    [ { FOR UPDATE | LOCK IN SHARE MODE } [ OF <table_list> ] [ NOWAIT | SKIP LOCKED ] ]
+        /*NOWAIT/SKIP LOCKED: MySQL 8.0+, MariaDB 10.3+*/
+    [ FOR SHARE [ OF <table_list> ] [ NOWAIT | SKIP LOCKED ] ]  /*MySQL 8.0+*/
+    [ INTO { OUTFILE '<filename>' [ <export_options> ] 
+           | DUMPFILE '<filename>'
+           | @<var_name> { , @<var_name> } } ]
+
+<select_expr> ::=
+    *
+  | <table_name> . *
+  | <expression> [ [ AS ] <alias> ]
+
+<table_reference> ::=
+    <table_factor>
+  | <join_table>
+
+<table_factor> ::=
+    <table_name> [ [ AS ] <alias> ] [ <index_hint_list> ]
+  | ( <select_statement> ) [ AS ] <alias> [ ( <column_list> ) ]
+  | ( <table_reference_list> )
+  | { OJ <table_reference> LEFT OUTER JOIN <table_reference> ON <condition> }
+  | VALUES <value_list> { , <value_list> } [ AS ] <alias> [ ( <column_list> ) ]
+    /*VALUES as table: MySQL 8.0.19+*/
+  | TABLE <table_name> [ ORDER BY <column_name> ] [ LIMIT <number> ]
+    /*TABLE statement: MySQL 8.0.19+*/
+
+<join_table> ::=
+    <table_reference> [ INNER | CROSS ] JOIN <table_factor> [ <join_condition> ]
+  | <table_reference> STRAIGHT_JOIN <table_factor> [ ON <condition> ]
+  | <table_reference> { LEFT | RIGHT } [ OUTER ] JOIN <table_reference> <join_condition>
+  | <table_reference> NATURAL [ { LEFT | RIGHT } [ OUTER ] ] JOIN <table_factor>
+
+<join_condition> ::=
+    ON <condition>
+  | USING ( <column_list> )
+
+<index_hint_list> ::=
+    <index_hint> { , <index_hint> }
+
+<index_hint> ::=
+    { USE | IGNORE | FORCE } { INDEX | KEY } [ FOR { JOIN | ORDER BY | GROUP BY } ] ( <index_list> )
+```
+
+#### Common Table Expressions (CTE)
+
+```ebnf
+<with_clause> ::=
+    WITH [ RECURSIVE ] <cte_list>
+
+<cte> ::=
+    <cte_name> [ ( <column_list> ) ] AS ( <select_statement> )
+```
+
+#### Window Functions
+
+```ebnf
+<window_function> ::=
+    <window_function_name> ( [ <expression_list> ] ) OVER <window_spec>
+
+<window_spec> ::=
+    ( [ <partition_clause> ] [ <order_clause> ] [ <frame_clause> ] )
+  | <window_name>
+
+<partition_clause> ::= PARTITION BY <expression_list>
+
+<order_clause> ::= ORDER BY <order_item_list>
+
+<frame_clause> ::=
+    { ROWS | RANGE } <frame_start>
+  | { ROWS | RANGE } BETWEEN <frame_start> AND <frame_end>
+
+<frame_start> ::=
+    CURRENT ROW
+  | UNBOUNDED PRECEDING
+  | <expression> PRECEDING
+  | <expression> FOLLOWING
+
+<frame_end> ::=
+    CURRENT ROW
+  | UNBOUNDED FOLLOWING
+  | <expression> PRECEDING
+  | <expression> FOLLOWING
+
+<window_function_name> ::=
+    ROW_NUMBER | RANK | DENSE_RANK | PERCENT_RANK | CUME_DIST
+  | NTILE | LAG | LEAD | FIRST_VALUE | LAST_VALUE | NTH_VALUE
+```
+
+### 5. Stored Programs
+
+#### Stored Procedures
+
+```ebnf
+<create_procedure> ::=
+    CREATE [ DEFINER = { <user> | CURRENT_USER } ]
+    PROCEDURE [ IF NOT EXISTS ] <sp_name> ( [ <parameter_list> ] )
+    [ <characteristic> { <characteristic> } ]
+    <routine_body>
+
+<parameter> ::=
+    [ IN | OUT | INOUT ] <param_name> <data_type>
+
+<characteristic> ::=
+    COMMENT '<string>'
+  | LANGUAGE SQL
+  | [ NOT ] DETERMINISTIC
+  | { CONTAINS SQL | NO SQL | READS SQL DATA | MODIFIES SQL DATA }
+  | SQL SECURITY { DEFINER | INVOKER }
+
+<routine_body> ::=
+    <sql_statement>
+  | <compound_statement>
+
+<compound_statement> ::=
+    [ <label> : ] BEGIN
+        [ <declaration_list> ]
+        <statement_list>
+    END [ <label> ]
+
+<declaration> ::=
+    DECLARE <variable_list> <data_type> [ DEFAULT <expression> ]
+  | DECLARE <condition_name> CONDITION FOR <condition_value>
+  | DECLARE <cursor_name> CURSOR FOR <select_statement>
+  | DECLARE { CONTINUE | EXIT | UNDO } HANDLER FOR <condition_value_list> <statement>
+
+<statement> ::=
+    <sql_statement>
+  | <compound_statement>
+  | <if_statement>
+  | <case_statement>
+  | <loop_statement>
+  | <while_statement>
+  | <repeat_statement>
+  | <leave_statement>
+  | <iterate_statement>
+  | <return_statement>
+  | <signal_statement>
+  | <resignal_statement>
+  | <get_diagnostics>
+  | <open_cursor>
+  | <fetch_cursor>
+  | <close_cursor>
+
+<if_statement> ::=
+    IF <condition> THEN <statement_list>
+    [ ELSEIF <condition> THEN <statement_list> ]
+    [ ELSE <statement_list> ]
+    END IF
+
+<case_statement> ::=
+    CASE <case_value>
+        WHEN <when_value> THEN <statement_list>
+        [ WHEN <when_value> THEN <statement_list> ]
+        [ ELSE <statement_list> ]
+    END CASE
+  | CASE
+        WHEN <condition> THEN <statement_list>
+        [ WHEN <condition> THEN <statement_list> ]
+        [ ELSE <statement_list> ]
+    END CASE
+
+<loop_statement> ::=
+    [ <label> : ] LOOP
+        <statement_list>
+    END LOOP [ <label> ]
+
+<while_statement> ::=
+    [ <label> : ] WHILE <condition> DO
+        <statement_list>
+    END WHILE [ <label> ]
+
+<repeat_statement> ::=
+    [ <label> : ] REPEAT
+        <statement_list>
+    UNTIL <condition>
+    END REPEAT [ <label> ]
+```
+
+#### Stored Functions
+
+```ebnf
+<create_function> ::=
+    CREATE [ DEFINER = { <user> | CURRENT_USER } ]
+    FUNCTION [ IF NOT EXISTS ] <sp_name> ( [ <parameter_list> ] )
+    RETURNS <data_type>
+    [ <characteristic> { <characteristic> } ]
+    <routine_body>
+```
+
+#### Triggers
+
+```ebnf
+<create_trigger> ::=
+    CREATE [ DEFINER = { <user> | CURRENT_USER } ]
+    TRIGGER [ IF NOT EXISTS ] <trigger_name>
+    { BEFORE | AFTER }
+    { INSERT | UPDATE | DELETE }
+    ON <table_name> FOR EACH ROW
+    [ { FOLLOWS | PRECEDES } <other_trigger_name> ]  /*MySQL 5.7.2+, MariaDB 10.2.3+*/
+    <trigger_body>
+
+<trigger_body> ::=
+    <statement>
+  | BEGIN <statement_list> END
+```
+
+#### Events
+
+```ebnf
+<create_event> ::=
+    CREATE [ DEFINER = { <user> | CURRENT_USER } ]
+    EVENT [ IF NOT EXISTS ] <event_name>
+    ON SCHEDULE <schedule>
+    [ ON COMPLETION [ NOT ] PRESERVE ]
+    [ ENABLE | DISABLE | DISABLE ON SLAVE ]
+    [ COMMENT '<string>' ]
+    DO <event_body>
+
+<schedule> ::=
+    AT <timestamp> [ + INTERVAL <interval> ]
+  | EVERY <interval>
+    [ STARTS <timestamp> [ + INTERVAL <interval> ] ]
+    [ ENDS <timestamp> [ + INTERVAL <interval> ] ]
+
+<interval> ::=
+    <quantity> { MICROSECOND | SECOND | MINUTE | HOUR 
+               | DAY | WEEK | MONTH | QUARTER | YEAR
+               | SECOND_MICROSECOND | MINUTE_MICROSECOND
+               | MINUTE_SECOND | HOUR_MICROSECOND
+               | HOUR_SECOND | HOUR_MINUTE
+               | DAY_MICROSECOND | DAY_SECOND
+               | DAY_MINUTE | DAY_HOUR | YEAR_MONTH }
+```
+
+### 6. User-Defined Functions (UDF)
+
+```ebnf
+<create_udf> ::=
+    CREATE [ AGGREGATE ] FUNCTION <function_name>
+    RETURNS { STRING | INTEGER | REAL | DECIMAL }
+    SONAME '<shared_library_name>'
+
+<drop_udf> ::=
+    DROP FUNCTION [ IF EXISTS ] <function_name>
+```
+
+### 7. Views
+
+```ebnf
+<create_view> ::=
+    CREATE [ OR REPLACE ]
+    [ ALGORITHM = { UNDEFINED | MERGE | TEMPTABLE } ]
+    [ DEFINER = { <user> | CURRENT_USER } ]
+    [ SQL SECURITY { DEFINER | INVOKER } ]
+    VIEW <view_name> [ ( <column_list> ) ]
+    AS <select_statement>
+    [ WITH [ CASCADED | LOCAL ] CHECK OPTION ]
+```
+
+### 8. Prepared Statements
+
+```ebnf
+<prepare_statement> ::=
+    PREPARE <stmt_name> FROM <preparable_stmt>
+
+<execute_statement> ::=
+    EXECUTE <stmt_name> [ USING @<var_name> { , @<var_name> } ]
+
+<deallocate_statement> ::=
+    { DEALLOCATE | DROP } PREPARE <stmt_name>
+```
+
+### 9. Transaction Control
+
+```ebnf
+<transaction_statement> ::=
+    START TRANSACTION [ <transaction_characteristic> { , <transaction_characteristic> } ]
+  | BEGIN [ WORK ]
+  | COMMIT [ WORK ] [ AND [ NO ] CHAIN ] [ [ NO ] RELEASE ]
+  | ROLLBACK [ WORK ] [ AND [ NO ] CHAIN ] [ [ NO ] RELEASE ]
+  | SAVEPOINT <savepoint_name>
+  | RELEASE SAVEPOINT <savepoint_name>
+  | ROLLBACK [ WORK ] TO [ SAVEPOINT ] <savepoint_name>
+  | SET TRANSACTION <transaction_characteristic> { , <transaction_characteristic> }
+
+<transaction_characteristic> ::=
+    { WITH CONSISTENT SNAPSHOT
+    | READ WRITE | READ ONLY
+    | ISOLATION LEVEL <isolation_level> }
+
+<isolation_level> ::=
+    READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE
+
+<xa_transaction> ::=
+    XA { START | BEGIN } <xid> [ JOIN | RESUME ]
+  | XA END <xid> [ SUSPEND [ FOR MIGRATE ] ]
+  | XA PREPARE <xid>
+  | XA COMMIT <xid> [ ONE PHASE ]
+  | XA ROLLBACK <xid>
+  | XA RECOVER [ CONVERT XID ]
+
+<xid> ::= '<gtrid>' [ , '<bqual>' [ , <format_id> ] ]
+```
+
+### 10. Lock Statements
+
+```ebnf
+<lock_tables> ::=
+    LOCK TABLES <table_lock_list>
+
+<table_lock> ::=
+    <table_name> [ [ AS ] <alias> ] <lock_type>
+
+<lock_type> ::=
+    READ [ LOCAL ]
+  | [ LOW_PRIORITY ] WRITE
+  | WRITE CONCURRENT  /*MariaDB*/
+
+<unlock_tables> ::= UNLOCK TABLES
+
+<lock_instance> ::=
+    LOCK INSTANCE FOR BACKUP  /*MySQL 8.0+*/
+  | UNLOCK INSTANCE
+```
+
+### 11. Handler Statements
+
+```ebnf
+<handler_statement> ::=
+    HANDLER <table_name> OPEN [ [ AS ] <alias> ]
+  | HANDLER <table_name> READ <index_name> { = | <= | >= | < | > } ( <value_list> )
+      [ WHERE <where_condition> ] [ LIMIT <limit> ]
+  | HANDLER <table_name> READ <index_name> { FIRST | NEXT | PREV | LAST }
+      [ WHERE <where_condition> ] [ LIMIT <limit> ]
+  | HANDLER <table_name> READ { FIRST | NEXT }
+      [ WHERE <where_condition> ] [ LIMIT <limit> ]
+  | HANDLER <table_name> CLOSE
+```
+
+### 12. JSON Functions and Operators
+
+```ebnf
+<json_function> ::=
+    JSON_ARRAY( [ <value> { , <value> } ] )
+  | JSON_OBJECT( [ <key> , <value> { , <key> , <value> } ] )
+  | JSON_QUOTE( <string> )
+  | JSON_CONTAINS( <json_doc> , <candidate> [ , <path> ] )
+  | JSON_CONTAINS_PATH( <json_doc> , <one_or_all> , <path> { , <path> } )
+  | JSON_EXTRACT( <json_doc> , <path> { , <path> } )
+  | JSON_KEYS( <json_doc> [ , <path> ] )
+  | JSON_SEARCH( <json_doc> , <one_or_all> , <search_str> [ , <escape_char> [ , <path> ] ] )
+  | JSON_VALUE( <json_doc> , <path> [ RETURNING <type> ] [ <on_behavior> ] )  /*MySQL 8.0.21+*/
+  | JSON_SET( <json_doc> , <path> , <value> { , <path> , <value> } )
+  | JSON_INSERT( <json_doc> , <path> , <value> { , <path> , <value> } )
+  | JSON_REPLACE( <json_doc> , <path> , <value> { , <path> , <value> } )
+  | JSON_REMOVE( <json_doc> , <path> { , <path> } )
+  | JSON_MERGE( <json_doc> , <json_doc> { , <json_doc> } )  /*Deprecated*/
+  | JSON_MERGE_PRESERVE( <json_doc> , <json_doc> { , <json_doc> } )  /*MySQL 5.7.22+*/
+  | JSON_MERGE_PATCH( <json_doc> , <json_doc> { , <json_doc> } )  /*MySQL 5.7.22+*/
+  | JSON_ARRAYAGG( <expression> [ ORDER BY <order_list> ] )  /*MySQL 5.7.22+*/
+  | JSON_OBJECTAGG( <key> , <value> )  /*MySQL 5.7.22+*/
+  | JSON_TABLE( <json_expr> , <path> COLUMNS ( <column_definition_list> ) )  /*MySQL 8.0+*/
+
+<json_operator> ::=
+    -> |    -- Extract JSON value
+    ->> |   -- Extract JSON value and unquote
+    @>      -- JSON contains (MariaDB 10.2.3+)
+
+<json_path> ::=
+    '$' [ <path_leg> { <path_leg> } ]
+
+<path_leg> ::=
+    . <member>
+  | [ <index> ]
+  | .* | [*]
+```
+
+### 13. Full-Text Search
+
+```ebnf
+<fulltext_search> ::=
+    MATCH ( <column_list> ) AGAINST ( <search_expr> [ <search_modifier> ] )
+
+<search_modifier> ::=
+    IN NATURAL LANGUAGE MODE
+  | IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION
+  | IN BOOLEAN MODE
+  | WITH QUERY EXPANSION
+```
+
+### 14. Regular Expressions
+
+```ebnf
+<regexp_operator> ::=
+    REGEXP | RLIKE       -- Pattern matching
+  | NOT REGEXP | NOT RLIKE
+
+<regexp_function> ::=
+    REGEXP_INSTR( <expr> , <pattern> [ , <position> [ , <occurrence> [ , <return_option> [ , <match_type> ] ] ] ] )
+  | REGEXP_LIKE( <expr> , <pattern> [ , <match_type> ] )  /*MySQL 8.0.4+*/
+  | REGEXP_REPLACE( <expr> , <pattern> , <replacement> [ , <position> [ , <occurrence> [ , <match_type> ] ] ] )
+  | REGEXP_SUBSTR( <expr> , <pattern> [ , <position> [ , <occurrence> [ , <match_type> ] ] ] )
+
+<match_type> ::= '<flags>'  -- Combination of: c i m n s u x
+```
+
+### 15. Partitioning
+
+```ebnf
+<partition_options> ::=
+    PARTITION BY
+    { [ LINEAR ] HASH ( <expression> )
+    | [ LINEAR ] KEY [ ALGORITHM = { 1 | 2 } ] ( <column_list> )
+    | RANGE ( <expression> | COLUMNS ( <column_list> ) )
+    | LIST ( <expression> | COLUMNS ( <column_list> ) )
+    | SYSTEM_TIME [ <system_time_partition> ]  /*MariaDB 10.3+*/ }
+    [ PARTITIONS <number> ]
+    [ SUBPARTITION BY
+        { [ LINEAR ] HASH ( <expression> )
+        | [ LINEAR ] KEY [ ALGORITHM = { 1 | 2 } ] ( <column_list> ) }
+        [ SUBPARTITIONS <number> ] ]
+    [ ( <partition_definition> { , <partition_definition> } ) ]
+
+<partition_definition> ::=
+    PARTITION <partition_name>
+    [ VALUES { LESS THAN { ( <value_list> ) | MAXVALUE }
+             | IN ( <value_list> ) } ]
+    [ [ STORAGE ] ENGINE [ = ] <engine_name> ]
+    [ COMMENT [ = ] '<string>' ]
+    [ DATA DIRECTORY [ = ] '<path>' ]
+    [ INDEX DIRECTORY [ = ] '<path>' ]
+    [ MAX_ROWS [ = ] <number> ]
+    [ MIN_ROWS [ = ] <number> ]
+    [ TABLESPACE [ = ] <tablespace_name> ]
+    [ ( <subpartition_definition> { , <subpartition_definition> } ) ]
+
+<alter_partition> ::=
+    ADD PARTITION ( <partition_definition> { , <partition_definition> } )
+  | DROP PARTITION <partition_names>
+  | DISCARD PARTITION { <partition_names> | ALL } TABLESPACE
+  | IMPORT PARTITION { <partition_names> | ALL } TABLESPACE
+  | TRUNCATE PARTITION { <partition_names> | ALL }
+  | COALESCE PARTITION <number>
+  | REORGANIZE PARTITION <partition_names> INTO ( <partition_definition> { , <partition_definition> } )
+  | EXCHANGE PARTITION <partition_name> WITH TABLE <table_name> [ { WITH | WITHOUT } VALIDATION ]
+  | ANALYZE PARTITION { <partition_names> | ALL }
+  | CHECK PARTITION { <partition_names> | ALL }
+  | OPTIMIZE PARTITION { <partition_names> | ALL }
+  | REBUILD PARTITION { <partition_names> | ALL }
+  | REPAIR PARTITION { <partition_names> | ALL }
+  | REMOVE PARTITIONING
+```
+
+### 16. LOAD DATA and SELECT INTO
+
+```ebnf
+<load_data> ::=
+    LOAD DATA [ LOW_PRIORITY | CONCURRENT ] [ LOCAL ] INFILE '<filename>'
+    [ REPLACE | IGNORE ]
+    INTO TABLE <table_name>
+    [ PARTITION ( <partition_list> ) ]
+    [ CHARACTER SET <charset_name> ]
+    [ { FIELDS | COLUMNS }
+        [ TERMINATED BY '<string>' ]
+        [ [ OPTIONALLY ] ENCLOSED BY '<char>' ]
+        [ ESCAPED BY '<char>' ] ]
+    [ LINES
+        [ STARTING BY '<string>' ]
+        [ TERMINATED BY '<string>' ] ]
+    [ IGNORE <number> { LINES | ROWS } ]
+    [ ( <column_or_user_var> { , <column_or_user_var> } ) ]
+    [ SET <assignment_list> ]
+
+<load_xml> ::=
+    LOAD XML [ LOW_PRIORITY | CONCURRENT ] [ LOCAL ] INFILE '<filename>'
+    [ REPLACE | IGNORE ]
+    INTO TABLE <table_name>
+    [ CHARACTER SET <charset_name> ]
+    [ ROWS IDENTIFIED BY '<tagname>' ]
+    [ IGNORE <number> { LINES | ROWS } ]
+    [ ( <column_or_user_var> { , <column_or_user_var> } ) ]
+    [ SET <assignment_list> ]
+
+<export_options> ::=
+    [ { FIELDS | COLUMNS }
+        [ TERMINATED BY '<string>' ]
+        [ [ OPTIONALLY ] ENCLOSED BY '<char>' ]
+        [ ESCAPED BY '<char>' ] ]
+    [ LINES
+        [ STARTING BY '<string>' ]
+        [ TERMINATED BY '<string>' ] ]
+```
+
+### 17. Account Management
+
+```ebnf
+<create_user> ::=
+    CREATE USER [ IF NOT EXISTS ]
+    <user_specification> { , <user_specification> }
+    [ REQUIRE { NONE | <tls_option> [ AND <tls_option> ] } ]
+    [ WITH <resource_option> { <resource_option> } ]
+    [ <password_option> { <password_option> } ]
+    [ COMMENT '<string>' ]  /*MySQL 8.0.21+*/
+    [ ATTRIBUTE '<json>' ]  /*MySQL 8.0.21+*/
+
+<user_specification> ::=
+    <user> [ <auth_option> ]
+
+<auth_option> ::=
+    IDENTIFIED BY '<password>'
+  | IDENTIFIED BY RANDOM PASSWORD  /*MySQL 8.0.18+*/
+  | IDENTIFIED WITH <auth_plugin> [ BY '<password>' | AS '<hash>' | INITIAL AUTHENTICATION <auth_string> ]
+  | IDENTIFIED VIA <auth_plugin> [ USING '<string>' | AS '<hash>' ] [ OR <auth_plugin> ... ]  /*MariaDB*/
+
+<grant_statement> ::=
+    GRANT <privilege_list> ON <privilege_level> TO <user_list>
+    [ REQUIRE { NONE | <tls_option> [ AND <tls_option> ] } ]
+    [ WITH { GRANT OPTION | <resource_option> { <resource_option> } } ]
+
+<privilege> ::=
+    ALL [ PRIVILEGES ]
+  | ALTER [ ROUTINE ]
+  | CREATE [ ROUTINE | TEMPORARY TABLES | VIEW ]
+  | DELETE | DROP | EVENT | EXECUTE | FILE | GRANT OPTION
+  | INDEX | INSERT | LOCK TABLES | PROCESS | PROXY
+  | REFERENCES | RELOAD | REPLICATION { CLIENT | SLAVE }
+  | SELECT | SHOW DATABASES | SHOW VIEW | SHUTDOWN
+  | SUPER | TRIGGER | UPDATE | USAGE
+  | APPLICATION_PASSWORD_ADMIN  /*MySQL 8.0+*/
+  | AUDIT_ADMIN  /*MySQL 8.0+*/
+  | BACKUP_ADMIN  /*MySQL 8.0+*/
+  | BINLOG_ADMIN  /*MySQL 8.0+*/
+  | BINLOG_ENCRYPTION_ADMIN  /*MySQL 8.0+*/
+  | CLONE_ADMIN  /*MySQL 8.0+*/
+  | CONNECTION_ADMIN  /*MySQL 8.0+*/
+  | ENCRYPTION_KEY_ADMIN  /*MySQL 8.0+*/
+  | FLUSH_OPTIMIZER_COSTS  /*MySQL 8.0+*/
+  | FLUSH_STATUS  /*MySQL 8.0+*/
+  | FLUSH_TABLES  /*MySQL 8.0+*/
+  | FLUSH_USER_RESOURCES  /*MySQL 8.0+*/
+  | GROUP_REPLICATION_ADMIN  /*MySQL 8.0+*/
+  | INNODB_REDO_LOG_ARCHIVE  /*MySQL 8.0+*/
+  | INNODB_REDO_LOG_ENABLE  /*MySQL 8.0+*/
+  | PASSWORDLESS_USER_ADMIN  /*MySQL 8.0+*/
+  | PERSIST_RO_VARIABLES_ADMIN  /*MySQL 8.0+*/
+  | REPLICATION_APPLIER  /*MySQL 8.0+*/
+  | REPLICATION_SLAVE_ADMIN  /*MySQL 8.0+*/
+  | RESOURCE_GROUP_ADMIN  /*MySQL 8.0+*/
+  | RESOURCE_GROUP_USER  /*MySQL 8.0+*/
+  | ROLE_ADMIN  /*MySQL 8.0+*/
+  | SESSION_VARIABLES_ADMIN  /*MySQL 8.0+*/
+  | SET_USER_ID  /*MySQL 8.0+*/
+  | SHOW_ROUTINE  /*MySQL 8.0+*/
+  | SYSTEM_USER  /*MySQL 8.0+*/
+  | SYSTEM_VARIABLES_ADMIN  /*MySQL 8.0+*/
+  | TABLE_ENCRYPTION_ADMIN  /*MySQL 8.0+*/
+  | VERSION_TOKEN_ADMIN  /*MySQL 8.0+*/
+  | XA_RECOVER_ADMIN  /*MySQL 8.0+*/
+
+<privilege_level> ::=
+    *
+  | *.*
+  | <db_name>.*
+  | <db_name>.<table_name>
+  | <table_name>
+  | <db_name>.<routine_name>
+```
+
+### 18. Roles (MySQL 8.0+, MariaDB 10.0+)
+
+```ebnf
+<create_role> ::=
+    CREATE ROLE [ IF NOT EXISTS ] <role> { , <role> }
+
+<grant_role> ::=
+    GRANT <role> { , <role> } TO <user> { , <user> }
+    [ WITH ADMIN OPTION ]
+
+<set_role> ::=
+    SET ROLE { DEFAULT | NONE | ALL | ALL EXCEPT <role> { , <role> } | <role> { , <role> } }
+
+<set_default_role> ::=
+    SET DEFAULT ROLE { NONE | ALL | <role> { , <role> } } TO <user> { , <user> }
+```
+
+### 19. Resource Groups (MySQL 8.0+)
+
+```ebnf
+<create_resource_group> ::=
+    CREATE RESOURCE GROUP <group_name>
+    TYPE = { SYSTEM | USER }
+    [ VCPU [=] <vcpu_spec> { , <vcpu_spec> } ]
+    [ THREAD_PRIORITY [=] <priority> ]
+    [ ENABLE | DISABLE ]
+
+<alter_resource_group> ::=
+    ALTER RESOURCE GROUP <group_name>
+    [ VCPU [=] <vcpu_spec> { , <vcpu_spec> } ]
+    [ THREAD_PRIORITY [=] <priority> ]
+    [ ENABLE | DISABLE ]
+    [ FORCE ]
+
+<set_resource_group> ::=
+    SET RESOURCE GROUP <group_name>
+    [ FOR <thread_id> { , <thread_id> } ]
+```
+
+### 20. System Versioning (MariaDB 10.3+)
+
+```ebnf
+<system_versioning> ::=
+    WITH SYSTEM VERSIONING
+
+<system_time_column> ::=
+    <row_start_column> <timestamp_type> GENERATED ALWAYS AS ROW START [ INVISIBLE ]
+  | <row_end_column> <timestamp_type> GENERATED ALWAYS AS ROW END [ INVISIBLE ]
+  | PERIOD FOR SYSTEM_TIME ( <row_start_column> , <row_end_column> )
+
+<system_versioned_query> ::=
+    SELECT ... FROM <table_name>
+    FOR SYSTEM_TIME { AS OF <point_in_time>
+                    | BETWEEN <point_in_time> AND <point_in_time>
+                    | FROM <point_in_time> TO <point_in_time>
+                    | ALL }
+
+<system_versioning_alter> ::=
+    ALTER TABLE <table_name> ADD SYSTEM VERSIONING
+  | ALTER TABLE <table_name> DROP SYSTEM VERSIONING
+```
+
+### 21. Sequences (MariaDB 10.3+)
+
+```ebnf
+<create_sequence> ::=
+    CREATE [ OR REPLACE ] [ TEMPORARY ] SEQUENCE [ IF NOT EXISTS ] <sequence_name>
+    [ INCREMENT [ BY ] <increment> ]
+    [ MINVALUE <minvalue> | NO MINVALUE | NOMINVALUE ]
+    [ MAXVALUE <maxvalue> | NO MAXVALUE | NOMAXVALUE ]
+    [ START [ WITH ] <start> ]
+    [ CACHE <cache> | NOCACHE ]
+    [ CYCLE | NOCYCLE ]
+    [ ENGINE = <engine_name> ]
+
+<sequence_operation> ::=
+    NEXT VALUE FOR <sequence_name>
+  | NEXTVAL( <sequence_name> )
+  | PREVIOUS VALUE FOR <sequence_name>
+  | LASTVAL( <sequence_name> )
+  | SETVAL( <sequence_name> , <value> [ , <is_used> ] )
+```
+
+### 22. CHECK Constraints (MySQL 8.0.16+, MariaDB 10.2+)
+
+```ebnf
+<check_constraint> ::=
+    [ CONSTRAINT [ <symbol> ] ] CHECK ( <expression> ) [ [ NOT ] ENFORCED ]
+```
+
+### 23. Lateral Derived Tables (MySQL 8.0.14+)
+
+```ebnf
+<lateral_derived_table> ::=
+    LATERAL ( <select_statement> ) [ AS ] <alias> [ ( <column_list> ) ]
+```
+
+### 24. VALUES Statement (MySQL 8.0.19+)
+
+```ebnf
+<values_statement> ::=
+    VALUES <row_constructor_list> [ ORDER BY <order_list> ] [ LIMIT <limit> ]
+
+<row_constructor> ::=
+    ROW ( <value_list> )
+```
+
+### 25. EXPLAIN Extensions
+
+```ebnf
+<explain_statement> ::=
+    { EXPLAIN | DESCRIBE | DESC }
+    [ EXTENDED | PARTITIONS | FORMAT = { TRADITIONAL | JSON | TREE } | ANALYZE ]  /*ANALYZE: MySQL 8.0.18+*/
+    { <select_statement>
+    | <delete_statement>
+    | <insert_statement>
+    | <replace_statement>
+    | <update_statement>
+    | FOR CONNECTION <connection_id> }
+  | { EXPLAIN | DESCRIBE | DESC } [ <table_name> [ <column_name> | <wild> ] ]
+```
+
+### 26. ANALYZE TABLE Extensions
+
+```ebnf
+<analyze_table> ::=
+    ANALYZE [ NO_WRITE_TO_BINLOG | LOCAL ]
+    TABLE <table_list>
+    [ UPDATE HISTOGRAM ON <column_list> [ WITH <buckets> BUCKETS ] ]  /*MySQL 8.0+*/
+    [ DROP HISTOGRAM ON <column_list> ]  /*MySQL 8.0+*/
+```
+
+### 27. MySQL-Specific Operators
+
+```ebnf
+<mysql_operator> ::=
+    -- Arithmetic
+    + | - | * | / | DIV | % | MOD
+
+    -- Comparison
+    = | <=> | != | <> | < | <= | > | >= | IS | IS NOT
+
+    -- Logical
+    AND | && | OR | || | XOR | NOT | !
+
+    -- Bitwise
+    & | | | ^ | ~ | << | >>
+
+    -- Assignment
+    := | =
+
+    -- Member of (MySQL 8.0.17+)
+    MEMBER OF( <json_array> )
+
+    -- RegExp
+    REGEXP | RLIKE | NOT REGEXP | NOT RLIKE
+
+    -- JSON (MySQL 5.7+)
+    -> | ->>
+```
+
+### 28. Comments and Hints
+
+```ebnf
+<comment> ::=
+    -- <comment_text>
+  | # <comment_text>
+  | /* <comment_text> */
+  | /*! <mysql_specific_code> */      -- MySQL-specific
+  | /*!50701 <version_specific> */    -- Version-specific
+
+<optimizer_hint> ::=
+    /*+ <hint_list> */
+
+<hint> ::=
+    BKA( <table_list> ) | NO_BKA( <table_list> )
+  | BNL( <table_list> ) | NO_BNL( <table_list> )
+  | HASH_JOIN( <table_list> ) | NO_HASH_JOIN( <table_list> )  /*MySQL 8.0.18+*/
+  | MERGE( <table_list> ) | NO_MERGE( <table_list> )
+  | INDEX( <table_name> <index_list> ) | NO_INDEX( <table_name> <index_list> )
+  | JOIN_ORDER( <table_list> ) | JOIN_PREFIX( <table_list> ) | JOIN_SUFFIX( <table_list> )
+  | SEMIJOIN( <strategy_list> ) | NO_SEMIJOIN( <strategy_list> )
+  | MAX_EXECUTION_TIME( <milliseconds> )
+  | SET_VAR( <var_assignment> )
+  | RESOURCE_GROUP( <group_name> )  /*MySQL 8.0+*/
+```
+
+### 29. MariaDB-Specific Features
+
+#### MariaDB Window Functions (10.2+)
+
+```ebnf
+<mariadb_window_function> ::=
+    MEDIAN( <expression> ) OVER <window_spec>  /*MariaDB 10.3.3+*/
+  | PERCENTILE_CONT( <fraction> ) WITHIN GROUP ( ORDER BY <expression> ) OVER <window_spec>
+  | PERCENTILE_DISC( <fraction> ) WITHIN GROUP ( ORDER BY <expression> ) OVER <window_spec>
+```
+
+#### MariaDB JSON Functions
+
+```ebnf
+<mariadb_json_function> ::=
+    JSON_COMPACT( <json_doc> )
+  | JSON_DETAILED( <json_doc> [ , <tab_size> ] )
+  | JSON_EQUALS( <json_doc> , <json_doc> )  /*MariaDB 10.7+*/
+  | JSON_NORMALIZE( <json_doc> )  /*MariaDB 10.7+*/
+  | JSON_OVERLAPS( <json_doc> , <json_doc> )  /*MariaDB 10.9+*/
+```
+
+#### MariaDB Application Time Periods (10.4+)
+
+```ebnf
+<application_time_period> ::=
+    PERIOD FOR <period_name> ( <start_column> , <end_column> )
+
+<without_overlaps> ::=
+    WITHOUT OVERLAPS ( <column_list> )
+```
+
+## Usage Notes
+
+1. **Version Compatibility**: Always check MySQL/MariaDB version for feature availability
+2. **Storage Engines**: Different storage engines support different features
+3. **Character Sets**: MySQL/MariaDB have extensive charset/collation support
+4. **SQL Modes**: SQL behavior can change based on sql_mode setting
+5. **Case Sensitivity**: Table names may be case-sensitive depending on OS
+6. **Identifier Quotes**: Use backticks ` for identifiers, single quotes ' for strings
+7. **Optimizer Hints**: Available in MySQL 5.7.7+ and MariaDB 10.0+
+8. **System Variables**: Extensive use of @@ and @ prefixed variables
+
+This grammar provides a comprehensive foundation for implementing MySQL/MariaDB SQL parsers, covering dialect-specific extensions and variations between MySQL and MariaDB.

--- a/references/sql_dialects/postgresql_bnf_ebnf.md
+++ b/references/sql_dialects/postgresql_bnf_ebnf.md
@@ -1,0 +1,760 @@
+# PostgreSQL SQL Extensions BNF/EBNF Grammar
+
+## Overview
+This document provides a comprehensive BNF/EBNF grammar specification for PostgreSQL SQL extensions and dialect-specific features. PostgreSQL extends the SQL standard with numerous proprietary features that need to be properly parsed.
+
+## Notation
+- `::=` defines a production rule
+- `|` indicates alternatives
+- `[ ]` indicates optional elements
+- `{ }` indicates zero or more repetitions
+- `( )` groups elements
+- `< >` denotes non-terminals
+- Terminal symbols are in UPPERCASE or quoted
+
+## Core Grammar Extensions
+
+### 1. Data Types
+
+```ebnf
+<postgresql_type> ::=
+    <standard_sql_type>
+  | <array_type>
+  | <composite_type>
+  | <domain_type>
+  | <enum_type>
+  | <range_type>
+  | <pseudo_type>
+  | <geometric_type>
+  | <network_type>
+  | <text_search_type>
+  | <uuid_type>
+  | <json_type>
+  | <xml_type>
+
+<array_type> ::= <data_type> "[" [ <integer> ] "]" { "[" [ <integer> ] "]" }
+                | <data_type> ARRAY [ "[" <integer> "]" ]
+
+<composite_type> ::= <identifier>
+
+<domain_type> ::= <identifier>
+
+<enum_type> ::= <identifier>
+
+<range_type> ::= INT4RANGE | INT8RANGE | NUMRANGE | TSRANGE 
+                | TSTZRANGE | DATERANGE | <identifier>
+
+<pseudo_type> ::= ANY | ANYELEMENT | ANYARRAY | ANYNONARRAY 
+                | ANYENUM | ANYRANGE | CSTRING | INTERNAL 
+                | LANGUAGE_HANDLER | FDW_HANDLER | RECORD 
+                | TRIGGER | VOID | OPAQUE
+
+<geometric_type> ::= POINT | LINE | LSEG | BOX | PATH | POLYGON | CIRCLE
+
+<network_type> ::= CIDR | INET | MACADDR | MACADDR8
+
+<text_search_type> ::= TSVECTOR | TSQUERY
+
+<uuid_type> ::= UUID
+
+<json_type> ::= JSON | JSONB
+
+<xml_type> ::= XML
+```
+
+### 2. DDL Extensions
+
+#### CREATE TABLE Extensions
+
+```ebnf
+<create_table_statement> ::=
+    CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE 
+    [ IF NOT EXISTS ] <table_name> 
+    [ PARTITION OF <parent_table> [ ( <partition_bound_spec> ) ] ]
+    ( <table_element_list> )
+    [ INHERITS ( <parent_table> { , <parent_table> } ) ]
+    [ PARTITION BY { RANGE | LIST | HASH } ( <partition_key> ) ]
+    [ WITH ( <storage_parameter_list> ) | WITH OIDS | WITHOUT OIDS ]
+    [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
+    [ TABLESPACE <tablespace_name> ]
+
+<table_element> ::=
+    <column_definition>
+  | <table_constraint>
+  | <like_clause>
+
+<column_definition> ::=
+    <column_name> <data_type> [ COLLATE <collation> ]
+    [ <column_constraint> { <column_constraint> } ]
+
+<column_constraint> ::=
+    [ CONSTRAINT <constraint_name> ]
+    { NOT NULL
+    | NULL
+    | CHECK ( <expression> ) [ NO INHERIT ]
+    | DEFAULT <default_expr>
+    | GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( <sequence_options> ) ]
+    | GENERATED ALWAYS AS ( <expression> ) STORED
+    | UNIQUE [ ( <column_list> ) ] <index_parameters>
+    | PRIMARY KEY <index_parameters>
+    | REFERENCES <reftable> [ ( <refcolumn> ) ] 
+        [ MATCH { FULL | PARTIAL | SIMPLE } ]
+        [ ON DELETE <referential_action> ] 
+        [ ON UPDATE <referential_action> ]
+    }
+    [ DEFERRABLE | NOT DEFERRABLE ] 
+    [ INITIALLY { DEFERRED | IMMEDIATE } ]
+
+<like_clause> ::=
+    LIKE <source_table> 
+    [ { INCLUDING | EXCLUDING } 
+      { COMMENTS | CONSTRAINTS | DEFAULTS | GENERATED | IDENTITY 
+      | INDEXES | STATISTICS | STORAGE | ALL } { ... } ]
+
+<partition_bound_spec> ::=
+    FOR VALUES <partition_bound_values>
+  | DEFAULT
+
+<partition_bound_values> ::=
+    IN ( <value_list> )
+  | FROM ( <value_list> ) TO ( <value_list> )
+  | WITH ( MODULUS <integer>, REMAINDER <integer> )
+```
+
+#### CREATE INDEX Extensions
+
+```ebnf
+<create_index_statement> ::=
+    CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ [ IF NOT EXISTS ] <index_name> ]
+    ON [ ONLY ] <table_name> [ USING <method> ]
+    ( <index_element> { , <index_element> } )
+    [ INCLUDE ( <column_name> { , <column_name> } ) ]
+    [ WITH ( <storage_parameter_list> ) ]
+    [ TABLESPACE <tablespace_name> ]
+    [ WHERE <predicate> ]
+
+<index_element> ::=
+    { <column_name> | ( <expression> ) } 
+    [ COLLATE <collation> ] 
+    [ <opclass> ] 
+    [ ASC | DESC ] 
+    [ NULLS { FIRST | LAST } ]
+
+<method> ::= BTREE | HASH | GIST | SPGIST | GIN | BRIN
+```
+
+### 3. DML Extensions
+
+#### INSERT Extensions
+
+```ebnf
+<insert_statement> ::=
+    [ WITH [ RECURSIVE ] <cte_list> ]
+    INSERT INTO <table_name> [ AS <alias> ] 
+    [ ( <column_list> ) ]
+    [ OVERRIDING { SYSTEM | USER } VALUE ]
+    { DEFAULT VALUES
+    | VALUES ( <value_list> ) { , ( <value_list> ) }
+    | <query> }
+    [ ON CONFLICT <conflict_clause> ]
+    [ RETURNING <output_list> ]
+
+<conflict_clause> ::=
+    [ ( <index_column_list> ) ] [ WHERE <condition> ]
+    DO { NOTHING | UPDATE SET <update_item_list> [ WHERE <condition> ] }
+```
+
+#### UPDATE Extensions
+
+```ebnf
+<update_statement> ::=
+    [ WITH [ RECURSIVE ] <cte_list> ]
+    UPDATE [ ONLY ] <table_name> [ * ] [ [ AS ] <alias> ]
+    SET <update_item_list>
+    [ FROM <from_list> ]
+    [ WHERE <condition> | WHERE CURRENT OF <cursor_name> ]
+    [ RETURNING <output_list> ]
+
+<update_item> ::=
+    <column_name> = { <expression> | DEFAULT }
+  | ( <column_list> ) = [ ROW ] ( { <expression> | DEFAULT } { , ... } )
+  | ( <column_list> ) = ( <sub_select> )
+```
+
+#### DELETE Extensions
+
+```ebnf
+<delete_statement> ::=
+    [ WITH [ RECURSIVE ] <cte_list> ]
+    DELETE FROM [ ONLY ] <table_name> [ * ] [ [ AS ] <alias> ]
+    [ USING <from_list> ]
+    [ WHERE <condition> | WHERE CURRENT OF <cursor_name> ]
+    [ RETURNING <output_list> ]
+```
+
+### 4. Query Extensions
+
+#### SELECT Extensions
+
+```ebnf
+<select_statement> ::=
+    [ WITH [ RECURSIVE ] <cte_list> ]
+    SELECT [ ALL | DISTINCT [ ON ( <expression_list> ) ] ]
+    [ * | <select_list> ]
+    [ FROM <from_list> ]
+    [ WHERE <condition> ]
+    [ GROUP BY <grouping_element_list> ]
+    [ HAVING <condition> ]
+    [ WINDOW <window_definition_list> ]
+    [ { UNION | INTERSECT | EXCEPT } [ ALL | DISTINCT ] <select> ]
+    [ ORDER BY <expression> [ ASC | DESC ] [ NULLS { FIRST | LAST } ] { , ... } ]
+    [ LIMIT { <count> | ALL } ]
+    [ OFFSET <start> [ ROW | ROWS ] ]
+    [ FETCH { FIRST | NEXT } [ <count> ] { ROW | ROWS } { ONLY | WITH TIES } ]
+    [ FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } 
+        [ OF <table_name> { , ... } ] [ NOWAIT | SKIP LOCKED ] { ... } ]
+
+<grouping_element> ::=
+    <expression>
+  | ( )
+  | ( <expression> { , <expression> } )
+  | ROLLUP ( { <expression> | ( <expression_list> ) } { , ... } )
+  | CUBE ( { <expression> | ( <expression_list> ) } { , ... } )
+  | GROUPING SETS ( <grouping_element> { , ... } )
+
+<from_item> ::=
+    [ ONLY ] <table_name> [ * ] [ [ AS ] <alias> [ ( <column_alias_list> ) ] ]
+        [ TABLESAMPLE <sampling_method> ( <argument> { , ... } ) 
+            [ REPEATABLE ( <seed> ) ] ]
+  | [ LATERAL ] ( <query> ) [ AS ] <alias> [ ( <column_alias_list> ) ]
+  | [ LATERAL ] <function_name> ( [ <argument_list> ] ) 
+        [ WITH ORDINALITY ] [ [ AS ] <alias> [ ( <column_alias_list> ) ] ]
+  | [ LATERAL ] ROWS FROM( <function_name> ( [ <argument_list> ] ) 
+        [ AS ( <column_definition_list> ) ] { , ... } )
+        [ WITH ORDINALITY ] [ [ AS ] <alias> [ ( <column_alias_list> ) ] ]
+  | <from_item> <join_type> <from_item> <join_condition>
+
+<join_type> ::=
+    [ INNER ] JOIN
+  | LEFT [ OUTER ] JOIN
+  | RIGHT [ OUTER ] JOIN
+  | FULL [ OUTER ] JOIN
+  | CROSS JOIN
+
+<join_condition> ::=
+    ON <condition>
+  | USING ( <column_list> )
+  | NATURAL
+```
+
+### 5. CTE and Window Functions
+
+```ebnf
+<cte> ::=
+    <cte_name> [ ( <column_list> ) ] AS [ [ NOT ] MATERIALIZED ] ( <query> )
+
+<window_definition> ::=
+    <window_name> AS ( <window_specification> )
+
+<window_specification> ::=
+    [ <existing_window_name> ]
+    [ PARTITION BY <expression_list> ]
+    [ ORDER BY <sort_specification_list> ]
+    [ <frame_clause> ]
+
+<frame_clause> ::=
+    { RANGE | ROWS | GROUPS } <frame_start> [ <frame_exclusion> ]
+  | { RANGE | ROWS | GROUPS } BETWEEN <frame_start> AND <frame_end> 
+        [ <frame_exclusion> ]
+
+<frame_start> ::=
+    UNBOUNDED PRECEDING
+  | <expression> PRECEDING
+  | CURRENT ROW
+  | <expression> FOLLOWING
+
+<frame_end> ::=
+    <expression> PRECEDING
+  | CURRENT ROW
+  | <expression> FOLLOWING
+  | UNBOUNDED FOLLOWING
+
+<frame_exclusion> ::=
+    EXCLUDE CURRENT ROW
+  | EXCLUDE GROUP
+  | EXCLUDE TIES
+  | EXCLUDE NO OTHERS
+```
+
+### 6. Procedural Language Extensions
+
+#### PL/pgSQL
+
+```ebnf
+<plpgsql_function> ::=
+    CREATE [ OR REPLACE ] FUNCTION <function_name> 
+    ( [ <parameter_list> ] )
+    RETURNS <return_type>
+    [ LANGUAGE PLPGSQL ]
+    [ TRANSFORM { FOR TYPE <type_name> } { , ... } ]
+    [ WINDOW ] [ IMMUTABLE | STABLE | VOLATILE | [ NOT ] LEAKPROOF ]
+    [ CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT ]
+    [ [ EXTERNAL ] SECURITY { INVOKER | DEFINER } ]
+    [ PARALLEL { UNSAFE | RESTRICTED | SAFE } ]
+    [ COST <execution_cost> ]
+    [ ROWS <result_rows> ]
+    [ SET <configuration_parameter> { TO <value> | = <value> | FROM CURRENT } ]
+    AS <function_body>
+
+<function_body> ::=
+    $$ <plpgsql_block> $$
+  | ' <plpgsql_block> '
+
+<plpgsql_block> ::=
+    [ DECLARE <declarations> ]
+    BEGIN
+        <statements>
+    [ EXCEPTION <exception_handlers> ]
+    END [ <label> ] ;
+
+<plpgsql_statement> ::=
+    <assignment>
+  | <if_statement>
+  | <case_statement>
+  | <loop_statement>
+  | <exit_statement>
+  | <continue_statement>
+  | <return_statement>
+  | <raise_statement>
+  | <assert_statement>
+  | <execute_statement>
+  | <sql_statement>
+  | <block>
+
+<assignment> ::=
+    <variable> := <expression> ;
+  | <variable> = <expression> ;
+
+<if_statement> ::=
+    IF <condition> THEN
+        <statements>
+    [ ELSIF <condition> THEN
+        <statements> ]
+    [ ELSE
+        <statements> ]
+    END IF ;
+
+<loop_statement> ::=
+    [ <<label>> ]
+    { LOOP
+    | WHILE <condition> LOOP
+    | FOR <name> IN [ REVERSE ] <expression> .. <expression> [ BY <expression> ] LOOP
+    | FOR <target> IN <query> LOOP
+    | FOR <target> IN EXECUTE <text_expression> [ USING <expression_list> ] LOOP
+    | FOREACH <target> [ SLICE <number> ] IN ARRAY <expression> LOOP }
+        <statements>
+    END LOOP [ <label> ] ;
+
+<return_statement> ::=
+    RETURN [ <expression> ] ;
+  | RETURN NEXT <expression> ;
+  | RETURN QUERY <query> ;
+  | RETURN QUERY EXECUTE <text_expression> [ USING <expression_list> ] ;
+```
+
+### 7. Advanced Features
+
+#### Arrays
+
+```ebnf
+<array_expression> ::=
+    ARRAY[ <value_list> ]
+  | ARRAY( <query> )
+  | <expression> [ <subscript> ] { [ <subscript> ] }
+
+<subscript> ::=
+    <expression>
+  | <expression> : <expression>
+
+<array_operator> ::=
+    = | <> | < | > | <= | >= | @> | <@ | && | ||
+```
+
+#### JSON/JSONB Operations
+
+```ebnf
+<json_expression> ::=
+    <expression> -> <key>           -- Get JSON object field
+  | <expression> -> <index>         -- Get JSON array element
+  | <expression> ->> <key>          -- Get JSON object field as text
+  | <expression> ->> <index>        -- Get JSON array element as text
+  | <expression> #> <path>          -- Get JSON object at path
+  | <expression> #>> <path>         -- Get JSON object at path as text
+  | <expression> @> <expression>    -- Contains
+  | <expression> <@ <expression>    -- Is contained by
+  | <expression> ? <key>            -- Key exists
+  | <expression> ?| <keys>          -- Any key exists
+  | <expression> ?& <keys>          -- All keys exist
+  | <expression> || <expression>    -- Concatenate
+
+<json_path> ::= '{' <path_element> { , <path_element> } '}'
+
+<json_aggregate> ::=
+    JSON_AGG( <expression> [ ORDER BY <sort_specification_list> ] )
+  | JSONB_AGG( <expression> [ ORDER BY <sort_specification_list> ] )
+  | JSON_OBJECT_AGG( <key>, <value> )
+  | JSONB_OBJECT_AGG( <key>, <value> )
+```
+
+#### Full Text Search
+
+```ebnf
+<text_search_expression> ::=
+    <tsvector> @@ <tsquery>                    -- Match
+  | <tsquery> @@ <tsvector>                    -- Match (commutative)
+  | <tsvector> || <tsvector>                   -- Concatenate
+  | TS_RANK( <tsvector>, <tsquery> )          -- Ranking
+  | TS_RANK_CD( <tsvector>, <tsquery> )       -- Cover density ranking
+  | TS_HEADLINE( <text>, <tsquery> )          -- Generate headline
+  | TO_TSVECTOR( [ <config>, ] <text> )       -- Convert to tsvector
+  | TO_TSQUERY( [ <config>, ] <text> )        -- Convert to tsquery
+  | PLAINTO_TSQUERY( [ <config>, ] <text> )   -- Plain to tsquery
+  | PHRASETO_TSQUERY( [ <config>, ] <text> )  -- Phrase to tsquery
+
+<tsquery_operator> ::=
+    & | | | ! | <-> | <N>
+```
+
+#### COPY Statement
+
+```ebnf
+<copy_statement> ::=
+    COPY <table_name> [ ( <column_list> ) ]
+    FROM { '<filename>' | PROGRAM '<command>' | STDIN }
+    [ [ WITH ] ( <option> { , <option> } ) ]
+    [ WHERE <condition> ]
+
+  | COPY { <table_name> [ ( <column_list> ) ] | ( <query> ) }
+    TO { '<filename>' | PROGRAM '<command>' | STDOUT }
+    [ [ WITH ] ( <option> { , <option> } ) ]
+
+<copy_option> ::=
+    FORMAT { TEXT | CSV | BINARY }
+  | FREEZE [ <boolean> ]
+  | DELIMITER '<delimiter_character>'
+  | NULL '<null_string>'
+  | HEADER [ <boolean> ]
+  | QUOTE '<quote_character>'
+  | ESCAPE '<escape_character>'
+  | FORCE_QUOTE { ( <column_list> ) | * }
+  | FORCE_NOT_NULL ( <column_list> )
+  | FORCE_NULL ( <column_list> )
+  | ENCODING '<encoding_name>'
+```
+
+### 8. System Catalog and Information Schema
+
+```ebnf
+<system_catalog_query> ::=
+    SELECT * FROM pg_catalog.<catalog_table>
+  | SELECT * FROM information_schema.<schema_view>
+
+<catalog_table> ::=
+    pg_class | pg_attribute | pg_index | pg_constraint
+  | pg_namespace | pg_type | pg_proc | pg_operator
+  | pg_database | pg_tablespace | pg_roles | pg_stat_activity
+  | { ... many more ... }
+```
+
+### 9. Transaction Control Extensions
+
+```ebnf
+<transaction_statement> ::=
+    BEGIN [ WORK | TRANSACTION ] [ <transaction_mode> { , ... } ]
+  | START TRANSACTION [ <transaction_mode> { , ... } ]
+  | COMMIT [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]
+  | ROLLBACK [ WORK | TRANSACTION ] [ AND [ NO ] CHAIN ]
+  | SAVEPOINT <savepoint_name>
+  | RELEASE [ SAVEPOINT ] <savepoint_name>
+  | ROLLBACK [ WORK | TRANSACTION ] TO [ SAVEPOINT ] <savepoint_name>
+  | PREPARE TRANSACTION <transaction_id>
+  | COMMIT PREPARED <transaction_id>
+  | ROLLBACK PREPARED <transaction_id>
+
+<transaction_mode> ::=
+    ISOLATION LEVEL { SERIALIZABLE | REPEATABLE READ | READ COMMITTED 
+                    | READ UNCOMMITTED }
+  | READ WRITE | READ ONLY
+  | [ NOT ] DEFERRABLE
+```
+
+### 10. PostgreSQL-Specific Operators
+
+```ebnf
+<postgresql_operator> ::=
+    -- Arithmetic
+    + | - | * | / | % | ^ | |/ | ||/ | ! | !! | @ | & | | | # | ~ | << | >>
+
+    -- Comparison
+    = | <> | != | < | > | <= | >= | <=> | IS DISTINCT FROM | IS NOT DISTINCT FROM
+
+    -- String
+    || | ~~ | ~~* | !~~ | !~~* | ~ | ~* | !~ | !~*
+
+    -- Geometric
+    @-@ | @@ | ## | <-> | && | &< | &> | <<| | |>> | &<| | |&> | <^ | >^
+
+    -- Network
+    << | <<= | >> | >>= | && | ~ | & | | | + | -
+
+    -- Text Search
+    @@ | || | && | !! | @> | <@
+
+    -- JSON/JSONB
+    -> | ->> | #> | #>> | @> | <@ | ? | ?| | ?& | || | - | #-
+
+    -- Array
+    @> | <@ | && | || | # | + | -
+
+    -- Range
+    @> | <@ | && | << | >> | &< | &> | -|- | + | * | -
+```
+
+### 11. Schema Management
+
+```ebnf
+<schema_statement> ::=
+    CREATE SCHEMA [ IF NOT EXISTS ] <schema_name> 
+        [ AUTHORIZATION <role_spec> ] [ <schema_element> { ... } ]
+  | ALTER SCHEMA <schema_name> { RENAME TO <new_name> | OWNER TO <role_spec> }
+  | DROP SCHEMA [ IF EXISTS ] <schema_name> { , ... } [ CASCADE | RESTRICT ]
+
+<set_schema> ::=
+    SET search_path TO <schema> { , <schema> }
+  | SET search_path = <schema> { , <schema> }
+```
+
+### 12. Extensions and Foreign Data Wrappers
+
+```ebnf
+<extension_statement> ::=
+    CREATE EXTENSION [ IF NOT EXISTS ] <extension_name>
+        [ WITH ] [ SCHEMA <schema_name> ]
+        [ VERSION <version> ]
+        [ CASCADE ]
+  | ALTER EXTENSION <extension_name> { UPDATE [ TO <version> ] 
+                                     | SET SCHEMA <schema_name> }
+  | DROP EXTENSION [ IF EXISTS ] <extension_name> { , ... } [ CASCADE | RESTRICT ]
+
+<foreign_data_wrapper> ::=
+    CREATE FOREIGN DATA WRAPPER <fdw_name>
+        [ HANDLER <handler_function> ]
+        [ VALIDATOR <validator_function> ]
+        [ OPTIONS ( <option_list> ) ]
+
+<foreign_server> ::=
+    CREATE SERVER [ IF NOT EXISTS ] <server_name>
+        [ TYPE '<server_type>' ] [ VERSION '<server_version>' ]
+        FOREIGN DATA WRAPPER <fdw_name>
+        [ OPTIONS ( <option_list> ) ]
+
+<foreign_table> ::=
+    CREATE FOREIGN TABLE [ IF NOT EXISTS ] <table_name> 
+        ( <column_definition_list> )
+        [ INHERITS ( <parent_table> { , ... } ) ]
+        SERVER <server_name>
+        [ OPTIONS ( <option_list> ) ]
+```
+
+### 13. Event Triggers and Rules
+
+```ebnf
+<event_trigger> ::=
+    CREATE EVENT TRIGGER <trigger_name>
+        ON <event>
+        [ WHEN <filter_variable> IN ( <filter_value> { , ... } ) [ AND ... ] ]
+        EXECUTE { FUNCTION | PROCEDURE } <function_name>()
+
+<event> ::= DDL_COMMAND_START | DDL_COMMAND_END | TABLE_REWRITE | SQL_DROP
+
+<rule_statement> ::=
+    CREATE [ OR REPLACE ] RULE <rule_name> AS
+        ON { SELECT | INSERT | UPDATE | DELETE }
+        TO <table_name> [ WHERE <condition> ]
+        DO [ ALSO | INSTEAD ] { NOTHING | <command> | ( <command_list> ) }
+```
+
+### 14. Tablespaces and Storage
+
+```ebnf
+<tablespace_statement> ::=
+    CREATE TABLESPACE <tablespace_name>
+        [ OWNER <role_name> ]
+        LOCATION '<directory>'
+        [ WITH ( <tablespace_option_list> ) ]
+
+<storage_parameter> ::=
+    fillfactor = <value>
+  | toast_tuple_target = <value>
+  | parallel_workers = <value>
+  | autovacuum_enabled = <boolean>
+  | autovacuum_vacuum_threshold = <value>
+  | autovacuum_vacuum_scale_factor = <value>
+  | { ... many more ... }
+```
+
+### 15. LISTEN/NOTIFY
+
+```ebnf
+<listen_statement> ::= LISTEN <channel_name>
+<unlisten_statement> ::= UNLISTEN { <channel_name> | * }
+<notify_statement> ::= NOTIFY <channel_name> [ , '<payload>' ]
+```
+
+### 16. Advisory Locks
+
+```ebnf
+<advisory_lock_function> ::=
+    pg_advisory_lock( <key> )
+  | pg_advisory_lock( <key1>, <key2> )
+  | pg_advisory_lock_shared( <key> )
+  | pg_advisory_lock_shared( <key1>, <key2> )
+  | pg_try_advisory_lock( <key> )
+  | pg_try_advisory_lock( <key1>, <key2> )
+  | pg_try_advisory_lock_shared( <key> )
+  | pg_try_advisory_lock_shared( <key1>, <key2> )
+  | pg_advisory_unlock( <key> )
+  | pg_advisory_unlock( <key1>, <key2> )
+  | pg_advisory_unlock_shared( <key> )
+  | pg_advisory_unlock_shared( <key1>, <key2> )
+  | pg_advisory_unlock_all()
+```
+
+### 17. Row Level Security
+
+```ebnf
+<row_security> ::=
+    ALTER TABLE <table_name> ENABLE ROW LEVEL SECURITY
+  | ALTER TABLE <table_name> DISABLE ROW LEVEL SECURITY
+  | ALTER TABLE <table_name> FORCE ROW LEVEL SECURITY
+  | ALTER TABLE <table_name> NO FORCE ROW LEVEL SECURITY
+
+<policy_statement> ::=
+    CREATE POLICY <policy_name> ON <table_name>
+        [ AS { PERMISSIVE | RESTRICTIVE } ]
+        [ FOR { ALL | SELECT | INSERT | UPDATE | DELETE } ]
+        [ TO { <role_name> | PUBLIC | CURRENT_USER | SESSION_USER } { , ... } ]
+        [ USING ( <using_expression> ) ]
+        [ WITH CHECK ( <check_expression> ) ]
+```
+
+### 18. Partitioning
+
+```ebnf
+<partition_statement> ::=
+    CREATE TABLE <partition_name> PARTITION OF <parent_table>
+        { FOR VALUES <partition_bound_spec> | DEFAULT }
+        [ PARTITION BY { RANGE | LIST | HASH } ( <partition_key> ) ]
+        [ <table_storage_parameters> ]
+
+<attach_partition> ::=
+    ALTER TABLE <parent_table> ATTACH PARTITION <partition_name>
+        { FOR VALUES <partition_bound_spec> | DEFAULT }
+
+<detach_partition> ::=
+    ALTER TABLE <parent_table> DETACH PARTITION <partition_name>
+        [ CONCURRENTLY | FINALIZE ]
+```
+
+### 19. MERGE Statement (PostgreSQL 15+)
+
+```ebnf
+<merge_statement> ::=
+    [ WITH <cte_list> ]
+    MERGE INTO <target_table> [ [ AS ] <target_alias> ]
+    USING <data_source> ON <join_condition>
+    <when_clause> { <when_clause> }
+
+<when_clause> ::=
+    WHEN MATCHED [ AND <condition> ] THEN <merge_update>
+  | WHEN NOT MATCHED [ AND <condition> ] THEN <merge_insert>
+  | WHEN MATCHED [ AND <condition> ] THEN DELETE
+
+<merge_update> ::=
+    UPDATE SET { <column_name> = { <expression> | DEFAULT } } { , ... }
+
+<merge_insert> ::=
+    INSERT [ ( <column_list> ) ] 
+    { VALUES ( { <expression> | DEFAULT } { , ... } ) | DEFAULT VALUES }
+```
+
+### 20. SQL/JSON Path Language (PostgreSQL 12+)
+
+```ebnf
+<jsonpath> ::=
+    <mode> <path_expression>
+
+<mode> ::= strict | lax
+
+<path_expression> ::=
+    $<accessor_expression>
+
+<accessor_expression> ::=
+    .<key>
+  | .<*>
+  | [<index>]
+  | [*]
+  | [<start> to <end>]
+  | ?(<filter_expression>)
+
+<jsonpath_operator> ::=
+    == | != | <> | < | <= | > | >= | =~
+  | starts with | like_regex | exists
+
+<jsonpath_function> ::=
+    .type() | .size() | .double() | .ceiling() | .floor()
+  | .abs() | .datetime() | .keyvalue()
+```
+
+## Usage Notes
+
+1. **Parser Implementation**: When implementing a parser based on this grammar:
+   - Handle PostgreSQL's dollar-quoted strings: `$tag$...$tag$`
+   - Support E'' escape strings
+   - Implement proper operator precedence
+   - Handle schema-qualified names: `schema.object`
+
+2. **Version Considerations**: 
+   - This grammar covers PostgreSQL 9.5+ features
+   - Some features (MERGE, SQL/JSON) require PostgreSQL 12+
+   - Always check PostgreSQL version for feature availability
+
+3. **Extensions**: PostgreSQL's extension system means additional syntax may be available depending on installed extensions (PostGIS, pg_trgm, etc.)
+
+4. **Case Sensitivity**: 
+   - Unquoted identifiers are folded to lowercase
+   - Quoted identifiers preserve case: "MyTable"
+
+5. **Comments**:
+   - Single line: `-- comment`
+   - Multi-line: `/* comment */`
+
+6. **String Literals**:
+   - Standard: `'string'`
+   - Escape: `E'string\n'`
+   - Dollar: `$$string$$` or `$tag$string$tag$`
+   - Unicode: `U&'string'`
+
+7. **Numeric Literals**:
+   - Integer: `123`, `-456`
+   - Decimal: `123.45`, `-0.001`
+   - Scientific: `1.23E+4`, `5e-10`
+   - Binary: `B'101010'`
+   - Hexadecimal: `X'DEADBEEF'`
+
+8. **Type Casting**:
+   - PostgreSQL style: `expression::type`
+   - SQL standard: `CAST(expression AS type)`
+   - Function style: `type(expression)`
+
+This grammar provides a comprehensive foundation for implementing a PostgreSQL SQL parser, covering the major extensions and PostgreSQL-specific features beyond standard SQL.

--- a/references/sql_dialects/tsql_mssql_bnf_ebnf.md
+++ b/references/sql_dialects/tsql_mssql_bnf_ebnf.md
@@ -1,0 +1,1260 @@
+# T-SQL (Microsoft SQL Server) BNF/EBNF Grammar
+
+## Overview
+This document provides a comprehensive BNF/EBNF grammar specification for T-SQL (Transact-SQL), Microsoft SQL Server's extension of SQL. T-SQL adds procedural programming, local variables, various support functions for string processing, date processing, mathematics, etc., and extends the standard SQL DDL and DML statements.
+
+## Notation
+- `::=` defines a production rule
+- `|` indicates alternatives
+- `[ ]` indicates optional elements
+- `{ }` indicates zero or more repetitions
+- `( )` groups elements
+- `< >` denotes non-terminals
+- Terminal symbols are in UPPERCASE or quoted
+- `/* Version */` indicates version-specific features
+
+## Core Grammar
+
+### 1. Data Types
+
+```ebnf
+<tsql_data_type> ::=
+    <exact_numeric_type>
+  | <approximate_numeric_type>
+  | <date_time_type>
+  | <character_string_type>
+  | <unicode_string_type>
+  | <binary_string_type>
+  | <other_data_type>
+
+<exact_numeric_type> ::=
+    BIT
+  | TINYINT
+  | SMALLINT
+  | INT | INTEGER
+  | BIGINT
+  | DECIMAL [ ( <precision> [ , <scale> ] ) ]
+  | DEC [ ( <precision> [ , <scale> ] ) ]
+  | NUMERIC [ ( <precision> [ , <scale> ] ) ]
+  | SMALLMONEY
+  | MONEY
+
+<approximate_numeric_type> ::=
+    FLOAT [ ( <mantissa> ) ]
+  | REAL
+
+<date_time_type> ::=
+    DATE  /* SQL Server 2008+ */
+  | TIME [ ( <fractional_seconds> ) ]  /* SQL Server 2008+ */
+  | DATETIME
+  | DATETIME2 [ ( <fractional_seconds> ) ]  /* SQL Server 2008+ */
+  | SMALLDATETIME
+  | DATETIMEOFFSET [ ( <fractional_seconds> ) ]  /* SQL Server 2008+ */
+
+<character_string_type> ::=
+    CHAR [ ( <length> ) ] [ COLLATE <collation_name> ]
+  | CHARACTER [ ( <length> ) ] [ COLLATE <collation_name> ]
+  | VARCHAR [ ( <length> | MAX ) ] [ COLLATE <collation_name> ]
+  | CHARACTER VARYING [ ( <length> | MAX ) ] [ COLLATE <collation_name> ]
+  | TEXT [ COLLATE <collation_name> ]  /* Deprecated */
+
+<unicode_string_type> ::=
+    NCHAR [ ( <length> ) ] [ COLLATE <collation_name> ]
+  | NVARCHAR [ ( <length> | MAX ) ] [ COLLATE <collation_name> ]
+  | NTEXT [ COLLATE <collation_name> ]  /* Deprecated */
+
+<binary_string_type> ::=
+    BINARY [ ( <length> ) ]
+  | VARBINARY [ ( <length> | MAX ) ]
+  | IMAGE  /* Deprecated */
+
+<other_data_type> ::=
+    CURSOR  /* Variables only */
+  | HIERARCHYID  /* SQL Server 2008+ */
+  | SQL_VARIANT
+  | TABLE  /* Variables and parameters */
+  | TIMESTAMP | ROWVERSION
+  | UNIQUEIDENTIFIER
+  | XML [ ( [ <xml_schema_collection> ] ) ]
+  | GEOMETRY  /* SQL Server 2008+ */
+  | GEOGRAPHY  /* SQL Server 2008+ */
+  | JSON  /* SQL Server 2016+ for JSON operations */
+```
+
+### 2. DDL Statements
+
+#### CREATE TABLE
+
+```ebnf
+<create_table_statement> ::=
+    CREATE TABLE [ <database_name> . [ <schema_name> ] . | <schema_name> . ] <table_name>
+    { ( <table_element> { , <table_element> } )
+      [ ON { <partition_scheme> ( <partition_column> ) | <filegroup> | DEFAULT } ]
+      [ TEXTIMAGE_ON { <filegroup> | DEFAULT } ]
+      [ FILESTREAM_ON { <partition_scheme> | <filegroup> | DEFAULT } ]
+      [ WITH ( <table_option> { , <table_option> } ) ]
+    | AS <select_statement> [ WITH ( <table_option> { , <table_option> } ) ] }  /* SQL Server 2014+ */
+
+<table_element> ::=
+    <column_definition>
+  | <computed_column_definition>
+  | <column_set_definition>  /* SQL Server 2008+ */
+  | <table_constraint>
+  | <index_definition>  /* SQL Server 2014+ */
+  | <period_definition>  /* SQL Server 2016+ */
+
+<column_definition> ::=
+    <column_name> <data_type>
+    [ FILESTREAM ]  /* For varbinary(max) */
+    [ COLLATE <collation_name> ]
+    [ SPARSE ]  /* SQL Server 2008+ */
+    [ MASKED WITH ( FUNCTION = '<mask_function>' ) ]  /* SQL Server 2016+ */
+    [ [ CONSTRAINT <constraint_name> ] DEFAULT <default_expression> ]
+    [ IDENTITY [ ( <seed> , <increment> ) ] [ NOT FOR REPLICATION ] ]
+    [ GENERATED ALWAYS AS { ROW START | ROW END } [ HIDDEN ] ]  /* SQL Server 2016+ */
+    [ NULL | NOT NULL ]
+    [ ROWGUIDCOL ]
+    [ ENCRYPTED WITH ( <encryption_options> ) ]  /* SQL Server 2016+ */
+    [ <column_constraint> { <column_constraint> } ]
+    [ <column_index> ]  /* SQL Server 2014+ */
+
+<computed_column_definition> ::=
+    <column_name> AS <expression>
+    [ PERSISTED [ NOT NULL ] ]
+    [ [ CONSTRAINT <constraint_name> ] <column_constraint> { <column_constraint> } ]
+
+<column_constraint> ::=
+    [ CONSTRAINT <constraint_name> ]
+    { [ NULL | NOT NULL ]
+    | [ { PRIMARY KEY | UNIQUE } ] [ CLUSTERED | NONCLUSTERED ]
+        [ WITH FILLFACTOR = <fillfactor> 
+        | WITH ( <index_option> { , <index_option> } ) ]
+        [ ON { <partition_scheme> ( <partition_column> ) | <filegroup> | DEFAULT } ]
+    | [ FOREIGN KEY ] REFERENCES <referenced_table> [ ( <referenced_column> ) ]
+        [ ON DELETE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ ON UPDATE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ NOT FOR REPLICATION ]
+    | CHECK [ NOT FOR REPLICATION ] ( <logical_expression> ) }
+
+<table_constraint> ::=
+    [ CONSTRAINT <constraint_name> ]
+    { { PRIMARY KEY | UNIQUE } [ CLUSTERED | NONCLUSTERED ] ( <column_list> )
+        [ WITH FILLFACTOR = <fillfactor> 
+        | WITH ( <index_option> { , <index_option> } ) ]
+        [ ON { <partition_scheme> ( <partition_column> ) | <filegroup> | DEFAULT } ]
+    | FOREIGN KEY ( <column_list> ) REFERENCES <referenced_table> [ ( <column_list> ) ]
+        [ ON DELETE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ ON UPDATE { NO ACTION | CASCADE | SET NULL | SET DEFAULT } ]
+        [ NOT FOR REPLICATION ]
+    | CHECK [ NOT FOR REPLICATION ] ( <logical_expression> ) }
+
+<table_option> ::=
+    DATA_COMPRESSION = { NONE | ROW | PAGE | COLUMNSTORE | COLUMNSTORE_ARCHIVE }
+        [ ON PARTITIONS ( <partition_list> ) ]
+  | XML_COMPRESSION = { ON | OFF } [ ON PARTITIONS ( <partition_list> ) ]  /* SQL Server 2022+ */
+  | FILETABLE_DIRECTORY = '<directory_name>'  /* SQL Server 2012+ */
+  | FILETABLE_COLLATE_FILENAME = { <collation_name> | DATABASE_DEFAULT }
+  | FILETABLE_PRIMARY_KEY_CONSTRAINT_NAME = <constraint_name>
+  | FILETABLE_STREAMID_UNIQUE_CONSTRAINT_NAME = <constraint_name>
+  | FILETABLE_FULLPATH_UNIQUE_CONSTRAINT_NAME = <constraint_name>
+  | SYSTEM_VERSIONING = ON 
+        [ ( HISTORY_TABLE = <schema_name>.<history_table_name> 
+            [ , DATA_CONSISTENCY_CHECK = { ON | OFF } ] ) ]  /* SQL Server 2016+ */
+  | REMOTE_DATA_ARCHIVE = { ON [ ( <remote_data_archive_options> ) ] | OFF }  /* SQL Server 2016+ */
+  | MEMORY_OPTIMIZED = ON  /* SQL Server 2014+ */
+  | DURABILITY = { SCHEMA_ONLY | SCHEMA_AND_DATA }  /* SQL Server 2014+ */
+  | LEDGER = ON [ ( <ledger_options> ) ]  /* SQL Server 2022+ */
+  | LOCK_ESCALATION = { AUTO | TABLE | DISABLE }
+  | TRACK_COLUMNS_UPDATED = { ON | OFF }
+```
+
+#### CREATE INDEX
+
+```ebnf
+<create_index_statement> ::=
+    CREATE [ UNIQUE ] [ CLUSTERED | NONCLUSTERED ] INDEX <index_name>
+    ON [ <database_name> . [ <schema_name> ] . | <schema_name> . ] <object>
+    ( <column> [ ASC | DESC ] { , <column> [ ASC | DESC ] } )
+    [ INCLUDE ( <column_name> { , <column_name> } ) ]
+    [ WHERE <filter_predicate> ]  /* Filtered index */
+    [ WITH ( <index_option> { , <index_option> } ) ]
+    [ ON { <partition_scheme> ( <column_name> ) | <filegroup_name> | DEFAULT } ]
+    [ FILESTREAM_ON { <filestream_filegroup> | <partition_scheme> | NULL } ]
+
+<columnstore_index> ::=
+    CREATE [ CLUSTERED | NONCLUSTERED ] COLUMNSTORE INDEX <index_name>
+    ON [ <database_name> . [ <schema_name> ] . | <schema_name> . ] <table_name>
+    [ ( <column_name> { , <column_name> } ) ]  /* NONCLUSTERED only */
+    [ WHERE <filter_predicate> ]  /* SQL Server 2016+ */
+    [ WITH ( <columnstore_index_option> { , <columnstore_index_option> } ) ]
+    [ ON { <partition_scheme> ( <column_name> ) | <filegroup_name> | DEFAULT } ]
+
+<index_option> ::=
+    PAD_INDEX = { ON | OFF }
+  | FILLFACTOR = <fillfactor>
+  | SORT_IN_TEMPDB = { ON | OFF }
+  | IGNORE_DUP_KEY = { ON | OFF }
+  | STATISTICS_NORECOMPUTE = { ON | OFF }
+  | STATISTICS_INCREMENTAL = { ON | OFF }  /* SQL Server 2014+ */
+  | DROP_EXISTING = { ON | OFF }
+  | ONLINE = { ON [ ( <low_priority_lock_wait> ) ] | OFF }
+  | RESUMABLE = { ON | OFF }  /* SQL Server 2017+ */
+  | MAX_DURATION = <time> [ MINUTES ]  /* SQL Server 2017+ */
+  | ALLOW_ROW_LOCKS = { ON | OFF }
+  | ALLOW_PAGE_LOCKS = { ON | OFF }
+  | OPTIMIZE_FOR_SEQUENTIAL_KEY = { ON | OFF }  /* SQL Server 2019+ */
+  | MAXDOP = <max_degree_of_parallelism>
+  | DATA_COMPRESSION = { NONE | ROW | PAGE | COLUMNSTORE | COLUMNSTORE_ARCHIVE }
+        [ ON PARTITIONS ( <partition_list> ) ]
+  | XML_COMPRESSION = { ON | OFF } [ ON PARTITIONS ( <partition_list> ) ]  /* SQL Server 2022+ */
+  | COMPRESSION_DELAY = <delay> [ MINUTES ]
+  | BUCKET_COUNT = <bucket_count>  /* Memory-optimized tables only */
+```
+
+#### CREATE VIEW
+
+```ebnf
+<create_view_statement> ::=
+    CREATE [ OR ALTER ] VIEW [ <schema_name> . ] <view_name> 
+    [ ( <column_name> { , <column_name> } ) ]
+    [ WITH { ENCRYPTION | SCHEMABINDING | VIEW_METADATA } { , ... } ]
+    AS <select_statement>
+    [ WITH CHECK OPTION ]
+
+<indexed_view> ::=
+    /* Create view WITH SCHEMABINDING, then create UNIQUE CLUSTERED INDEX */
+```
+
+#### CREATE SCHEMA
+
+```ebnf
+<create_schema_statement> ::=
+    CREATE SCHEMA { <schema_name> | AUTHORIZATION <owner_name> 
+                  | <schema_name> AUTHORIZATION <owner_name> }
+    [ <schema_element> { <schema_element> } ]
+
+<schema_element> ::=
+    <create_table_statement>
+  | <create_view_statement>
+  | <grant_statement>
+  | <revoke_statement>
+  | <deny_statement>
+```
+
+### 3. DML Statements
+
+#### INSERT
+
+```ebnf
+<insert_statement> ::=
+    [ WITH <common_table_expression> { , <common_table_expression> } ]
+    INSERT [ TOP ( <expression> ) [ PERCENT ] ] 
+    [ INTO ] { <table_or_view> | <rowset_function> | <openquery> }
+    { [ ( <column_list> ) ] 
+      [ OUTPUT <output_clause> ]
+      { VALUES ( { <expression> | DEFAULT | NULL } { , ... } ) { , ( ... ) }
+      | <derived_table>
+      | <execute_statement>
+      | DEFAULT VALUES } }
+
+<bulk_insert> ::=
+    BULK INSERT [ <database_name> . [ <schema_name> ] . | <schema_name> . ] <table_name>
+    FROM '<data_file>'
+    [ WITH ( <bulk_insert_option> { , <bulk_insert_option> } ) ]
+```
+
+#### UPDATE
+
+```ebnf
+<update_statement> ::=
+    [ WITH <common_table_expression> { , <common_table_expression> } ]
+    UPDATE [ TOP ( <expression> ) [ PERCENT ] ] 
+    { <table_or_view> | <rowset_function> | <openquery> }
+    SET { <column_name> = { <expression> | DEFAULT | NULL }
+        | <variable> = <expression>
+        | <variable> = <column> = <expression>
+        | <column_name> { .WRITE ( <expression> , @Offset , @Length ) }
+        | @<variable> = <expression> } { , ... }
+    [ OUTPUT <output_clause> ]
+    [ FROM <table_source> { , <table_source> } ]
+    [ WHERE { <search_condition> | CURRENT OF { { [ GLOBAL ] <cursor_name> } | <cursor_variable> } } ]
+    [ OPTION ( <query_hint> { , <query_hint> } ) ]
+```
+
+#### DELETE
+
+```ebnf
+<delete_statement> ::=
+    [ WITH <common_table_expression> { , <common_table_expression> } ]
+    DELETE [ TOP ( <expression> ) [ PERCENT ] ]
+    [ FROM ] { <table_or_view> | <rowset_function> | <openquery> }
+    [ OUTPUT <output_clause> ]
+    [ FROM <table_source> { , <table_source> } ]
+    [ WHERE { <search_condition> | CURRENT OF { { [ GLOBAL ] <cursor_name> } | <cursor_variable> } } ]
+    [ OPTION ( <query_hint> { , <query_hint> } ) ]
+
+<truncate_table> ::=
+    TRUNCATE TABLE [ <database_name> . [ <schema_name> ] . | <schema_name> . ] <table_name>
+    [ WITH ( PARTITIONS ( <partition_list> ) ) ]  /* SQL Server 2016+ */
+```
+
+#### MERGE
+
+```ebnf
+<merge_statement> ::=
+    [ WITH <common_table_expression> { , <common_table_expression> } ]
+    MERGE [ TOP ( <expression> ) [ PERCENT ] ]
+    [ INTO ] <target_table> [ [ AS ] <alias> ]
+    USING <table_source> ON <merge_search_condition>
+    [ <when_matched_clause> ]
+    [ <when_not_matched_by_target_clause> ]
+    [ <when_not_matched_by_source_clause> ]
+    [ OUTPUT <output_clause> ]
+    [ OPTION ( <query_hint> { , <query_hint> } ) ] ;
+
+<when_matched_clause> ::=
+    WHEN MATCHED [ AND <search_condition> ] THEN
+    { UPDATE SET { <column_name> = <expression> } { , ... } | DELETE }
+
+<when_not_matched_by_target_clause> ::=
+    WHEN NOT MATCHED [ BY TARGET ] [ AND <search_condition> ] THEN
+    INSERT [ ( <column_list> ) ] { VALUES ( <value_list> ) | DEFAULT VALUES }
+
+<when_not_matched_by_source_clause> ::=
+    WHEN NOT MATCHED BY SOURCE [ AND <search_condition> ] THEN
+    { UPDATE SET { <column_name> = <expression> } { , ... } | DELETE }
+```
+
+#### SELECT
+
+```ebnf
+<select_statement> ::=
+    [ WITH <common_table_expression> { , <common_table_expression> } ]
+    <query_expression>
+    [ ORDER BY <order_by_clause> ]
+    [ FOR { BROWSE 
+          | XML { RAW [ ( '<element_name>' ) ] | AUTO | EXPLICIT | PATH [ ( '<element_name>' ) ] }
+              [ , { XMLDATA | XMLSCHEMA [ ( '<schema>' ) ] } ]
+              [ , ELEMENTS [ { XSINIL | ABSENT } ] ]
+              [ , ROOT [ ( '<root_name>' ) ] ]
+              [ , TYPE ]
+              [ , BINARY BASE64 ]
+          | JSON { AUTO | PATH } [ , ROOT [ ( '<root_name>' ) ] ] 
+              [ , INCLUDE_NULL_VALUES ] [ , WITHOUT_ARRAY_WRAPPER ]  /* SQL Server 2016+ */ } ]
+    [ OPTION ( <query_hint> { , <query_hint> } ) ]
+
+<query_expression> ::=
+    { <query_specification> | ( <query_expression> ) }
+    [ { UNION [ ALL ] | EXCEPT | INTERSECT } <query_specification> | ( <query_expression> ) ]
+
+<query_specification> ::=
+    SELECT [ ALL | DISTINCT ] [ TOP ( <expression> ) [ PERCENT ] [ WITH TIES ] ]
+    <select_list>
+    [ INTO <new_table> ]
+    [ FROM <table_source> { , <table_source> } ]
+    [ WHERE <search_condition> ]
+    [ GROUP BY [ ALL ] <group_by_item> { , <group_by_item> } [ WITH { CUBE | ROLLUP } ] ]
+    [ HAVING <search_condition> ]
+
+<select_list> ::=
+    { * 
+    | { <table_name> | <table_alias> } . * 
+    | { <expression> [ [ AS ] <column_alias> ] 
+      | <column_alias> = <expression> } } { , ... }
+
+<table_source> ::=
+    { <table_or_view_name> [ [ AS ] <alias> ] [ WITH ( <table_hint> { , <table_hint> } ) ]
+    | <rowset_function> [ [ AS ] <alias> ] [ ( <column_alias_list> ) ]
+    | <openquery>
+    | <openrowset>
+    | <opendatasource>
+    | <openxml>
+    | <derived_table> [ [ AS ] <alias> ] [ ( <column_alias_list> ) ]
+    | <joined_table>
+    | <pivoted_table>
+    | <unpivoted_table>
+    | <table_valued_function>
+    | CHANGETABLE ( { CHANGES | VERSION } <table_name> , ... )  /* SQL Server 2008+ */
+    | <graph_table> }  /* SQL Server 2017+ */
+
+<joined_table> ::=
+    <table_source> <join_type> <table_source> ON <search_condition>
+  | <table_source> CROSS JOIN <table_source>
+  | <table_source> { CROSS | OUTER } APPLY <table_source>
+
+<join_type> ::=
+    [ INNER ] JOIN
+  | { LEFT | RIGHT | FULL } [ OUTER ] JOIN
+
+<pivoted_table> ::=
+    <table_source> PIVOT ( <aggregate_function> ( <value_column> )
+    FOR <pivot_column> IN ( <column_list> ) ) [ [ AS ] <alias> ]
+
+<unpivoted_table> ::=
+    <table_source> UNPIVOT ( <value_column> 
+    FOR <pivot_column> IN ( <column_list> ) ) [ [ AS ] <alias> ]
+
+<derived_table> ::=
+    ( <select_statement> )
+
+<common_table_expression> ::=
+    <cte_name> [ ( <column_name> { , <column_name> } ) ]
+    AS ( <cte_query_definition> )
+```
+
+### 4. Procedural Extensions
+
+#### Stored Procedures
+
+```ebnf
+<create_procedure> ::=
+    CREATE [ OR ALTER ] { PROC | PROCEDURE } [ <schema_name> . ] <procedure_name>
+    [ ; <number> ]  /* Numbered procedures - deprecated */
+    [ { @<parameter_name> [ <type_schema_name> . ] <data_type>
+        [ VARYING ] [ = <default> ] [ OUT | OUTPUT ] [ READONLY ] } ] { , ... }
+    [ WITH { ENCRYPTION | RECOMPILE | EXECUTE AS <execute_as> } { , ... } ]
+    [ FOR REPLICATION ]
+    AS { [ BEGIN ] <sql_statement> { ; <sql_statement> } [ END ] | EXTERNAL NAME <assembly_method> }
+
+<execute_procedure> ::=
+    [ { EXEC | EXECUTE } ] { [ @<return_status> = ] <procedure_name> [ ; <number> ] 
+                           | @<procedure_name_var> }
+    [ { @<parameter_name> = } { <value> | @<variable> [ OUTPUT ] | DEFAULT } ] { , ... }
+    [ WITH { RECOMPILE | RESULT SETS { UNDEFINED | NONE | <result_sets_definition> } } ]
+```
+
+#### Functions
+
+```ebnf
+<create_function> ::=
+    CREATE [ OR ALTER ] FUNCTION [ <schema_name> . ] <function_name>
+    ( [ { @<parameter_name> [ AS ] [ <type_schema_name> . ] <parameter_data_type>
+        [ = <default> ] [ READONLY ] } ] { , ... } )
+    RETURNS { <return_data_type> | TABLE [ <table_type_definition> ] }
+    [ WITH { ENCRYPTION | SCHEMABINDING | RETURNS NULL ON NULL INPUT 
+           | CALLED ON NULL INPUT | EXECUTE AS <execute_as> 
+           | INLINE = { ON | OFF } } { , ... } ]  /* INLINE: SQL Server 2019+ */
+    [ AS ]
+    { RETURN <scalar_expression>  /* Scalar function */
+    | BEGIN <function_body> RETURN <scalar_expression> END  /* Multi-statement scalar */
+    | RETURN [ ( ] <select_statement> [ ) ]  /* Inline table-valued */
+    | BEGIN <function_body> RETURN END  /* Multi-statement table-valued */
+    | EXTERNAL NAME <assembly_method> }  /* CLR function */
+
+<table_type_definition> ::=
+    ( { <column_definition> | <computed_column_definition> 
+      | <table_constraint> | <index_definition> } { , ... } )
+```
+
+#### Triggers
+
+```ebnf
+<create_trigger> ::=
+    CREATE [ OR ALTER ] TRIGGER [ <schema_name> . ] <trigger_name>
+    ON { <table_name> | DATABASE | ALL SERVER }
+    [ WITH { ENCRYPTION | EXECUTE AS <execute_as> } { , ... } ]
+    { { FOR | AFTER | INSTEAD OF } { [ INSERT ] [ , ] [ UPDATE ] [ , ] [ DELETE ] }
+      [ WITH APPEND ]  /* Deprecated */
+      [ NOT FOR REPLICATION ]
+      AS <sql_statement> { ; <sql_statement> } }
+    | { FOR | AFTER } { <ddl_event> } { , ... }
+      AS <sql_statement> { ; <sql_statement> }  /* DDL trigger */
+    | { FOR | AFTER } LOGON
+      AS <sql_statement> { ; <sql_statement> }  /* Logon trigger */
+
+<enable_disable_trigger> ::=
+    { ENABLE | DISABLE } TRIGGER { [ <schema_name> . ] <trigger_name> | ALL }
+    ON { [ <schema_name> . ] <object_name> | DATABASE | ALL SERVER }
+```
+
+### 5. Control Flow
+
+```ebnf
+<control_flow_statement> ::=
+    <begin_end_block>
+  | <if_else_statement>
+  | <while_statement>
+  | <break_statement>
+  | <continue_statement>
+  | <goto_statement>
+  | <return_statement>
+  | <waitfor_statement>
+  | <try_catch_block>
+  | <throw_statement>
+
+<begin_end_block> ::=
+    BEGIN { <sql_statement> ; } END
+
+<if_else_statement> ::=
+    IF <boolean_expression> <sql_statement> [ ; ]
+    [ ELSE <sql_statement> [ ; ] ]
+
+<while_statement> ::=
+    WHILE <boolean_expression> <sql_statement> [ ; ]
+    [ BREAK ] [ CONTINUE ]
+
+<break_statement> ::= BREAK
+
+<continue_statement> ::= CONTINUE
+
+<goto_statement> ::= GOTO <label>
+<label_declaration> ::= <label> :
+
+<return_statement> ::= RETURN [ <integer_expression> ]
+
+<waitfor_statement> ::=
+    WAITFOR { DELAY '<time_interval>' | TIME '<time>' 
+            | [ ( ] <receive_statement> [ ) ] [ , TIMEOUT <timeout> ] }
+
+<try_catch_block> ::=
+    BEGIN TRY
+        { <sql_statement> ; }
+    END TRY
+    BEGIN CATCH
+        { <sql_statement> ; }
+    END CATCH
+
+<throw_statement> ::=
+    THROW [ { <error_number> , '<message>' , <state> } ] ;  /* SQL Server 2012+ */
+
+<raiserror_statement> ::=
+    RAISERROR ( { <msg_id> | <msg_str> | @<local_variable> }
+        { , <severity> , <state> }
+        [ , <argument> { , <argument> } ] )
+    [ WITH { LOG | NOWAIT | SETERROR } { , ... } ]
+```
+
+### 6. Variables and Parameters
+
+```ebnf
+<declare_statement> ::=
+    DECLARE { @<local_variable> [ AS ] <data_type> [ = <value> ] } { , ... }
+  | DECLARE @<local_variable> [ AS ] TABLE <table_type_definition>
+  | DECLARE @<local_variable> [ AS ] [ <type_schema_name> . ] <user_defined_table_type>
+  | DECLARE <cursor_name> [ INSENSITIVE ] [ SCROLL ] CURSOR 
+    [ FOR { <select_statement> [ FOR { READ ONLY | UPDATE [ OF <column_list> ] } ] } ]
+    [ LOCAL | GLOBAL ] [ FORWARD_ONLY | SCROLL ] 
+    [ STATIC | KEYSET | DYNAMIC | FAST_FORWARD ]
+    [ READ_ONLY | SCROLL_LOCKS | OPTIMISTIC ]
+    [ TYPE_WARNING ]
+
+<set_statement> ::=
+    SET { @<local_variable> = <expression>
+        | @<local_variable> = <column> = <expression>
+        | @<local_variable> { += | -= | *= | /= | %= | &= | ^= | |= } <expression>
+        | @<cursor_variable> = CURSOR [ FORWARD_ONLY | SCROLL ] 
+            [ STATIC | KEYSET | DYNAMIC | FAST_FORWARD ]
+            [ READ_ONLY | SCROLL_LOCKS | OPTIMISTIC ]
+            [ TYPE_WARNING ]
+            FOR <select_statement>
+            [ FOR { READ ONLY | UPDATE [ OF <column_list> ] } ] }
+
+<select_assignment> ::=
+    SELECT { @<local_variable> = <expression> } { , ... }
+    [ FROM <table_source> { , <table_source> } ]
+    [ WHERE <search_condition> ]
+    /* Other SELECT clauses */
+```
+
+### 7. Cursors
+
+```ebnf
+<cursor_operations> ::=
+    <declare_cursor>
+  | <open_cursor>
+  | <fetch_cursor>
+  | <close_cursor>
+  | <deallocate_cursor>
+
+<open_cursor> ::=
+    OPEN { { [ GLOBAL ] <cursor_name> } | <cursor_variable> }
+
+<fetch_cursor> ::=
+    FETCH [ [ NEXT | PRIOR | FIRST | LAST 
+           | ABSOLUTE { <n> | @<nvar> } 
+           | RELATIVE { <n> | @<nvar> } ] FROM ]
+    { { [ GLOBAL ] <cursor_name> } | @<cursor_variable> }
+    [ INTO @<variable_name> { , @<variable_name> } ]
+
+<close_cursor> ::=
+    CLOSE { { [ GLOBAL ] <cursor_name> } | <cursor_variable> }
+
+<deallocate_cursor> ::=
+    DEALLOCATE { { [ GLOBAL ] <cursor_name> } | @<cursor_variable> }
+
+<cursor_status> ::=
+    @@CURSOR_ROWS | @@FETCH_STATUS
+```
+
+### 8. Transaction Management
+
+```ebnf
+<transaction_statement> ::=
+    <begin_transaction>
+  | <commit_transaction>
+  | <rollback_transaction>
+  | <save_transaction>
+  | <set_transaction>
+
+<begin_transaction> ::=
+    BEGIN { TRAN | TRANSACTION } 
+    [ { <transaction_name> | @<tran_name_variable> } [ WITH MARK [ '<description>' ] ] ]
+
+<commit_transaction> ::=
+    COMMIT [ { TRAN | TRANSACTION } [ <transaction_name> | @<tran_name_variable> ] ]
+    [ WITH ( DELAYED_DURABILITY = { OFF | ON } ) ]  /* SQL Server 2014+ */
+
+<rollback_transaction> ::=
+    ROLLBACK [ { TRAN | TRANSACTION } 
+    [ <transaction_name> | @<tran_name_variable> | <savepoint_name> | @<savepoint_variable> ] ]
+
+<save_transaction> ::=
+    SAVE { TRAN | TRANSACTION } { <savepoint_name> | @<savepoint_variable> }
+
+<set_transaction> ::=
+    SET TRANSACTION ISOLATION LEVEL 
+    { READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SNAPSHOT | SERIALIZABLE }
+  | SET IMPLICIT_TRANSACTIONS { ON | OFF }
+  | SET XACT_ABORT { ON | OFF }
+```
+
+### 9. Error Handling
+
+```ebnf
+<error_functions> ::=
+    ERROR_NUMBER() | ERROR_SEVERITY() | ERROR_STATE()
+  | ERROR_PROCEDURE() | ERROR_LINE() | ERROR_MESSAGE()
+
+<try_catch_functions> ::=
+    XACT_STATE() | @@TRANCOUNT
+
+<error_handling> ::=
+    BEGIN TRY
+        -- Statements
+    END TRY
+    BEGIN CATCH
+        -- Error handling
+        [ THROW ; ]  /* Re-throw error */
+    END CATCH
+```
+
+### 10. Dynamic SQL
+
+```ebnf
+<execute_string> ::=
+    { EXEC | EXECUTE } ( { @<string_variable> | '<tsql_string>' } [ + ... ] )
+    [ [ AS ] { LOGIN | USER } = '<name>' ]
+    [ AT { <linked_server_name> | [ <data_source> ] } ]
+    [ ; ]
+
+<sp_executesql> ::=
+    [ { EXEC | EXECUTE } ] sp_executesql 
+    { @<statement> | N'<tsql_string>' } 
+    [ , { @<params> | N'@<parameter_name> <data_type> [ OUT | OUTPUT ] { , ... }' } ]
+    [ , { @<param1> = <value1> [ OUT | OUTPUT ] } { , ... } ]
+```
+
+### 11. Temporary Objects
+
+```ebnf
+<temporary_table> ::=
+    CREATE TABLE { #<local_temp_table> | ##<global_temp_table> } ...
+
+<table_variable> ::=
+    DECLARE @<table_variable> TABLE <table_type_definition>
+
+<common_table_expression> ::=
+    WITH [ XMLNAMESPACES , ] [ <common_table_expression> { , ... } ]
+    <cte_name> [ ( <column_name> { , <column_name> } ) ]
+    AS ( <cte_query_definition> )
+```
+
+### 12. XML Support
+
+```ebnf
+<xml_data_type_methods> ::=
+    <xml_instance>.<method_name> ( <parameters> )
+
+<xml_methods> ::=
+    query ( '<XQuery>' )
+  | value ( '<XQuery>' , '<sql_type>' )
+  | exist ( '<XQuery>' )
+  | modify ( '<XML_DML>' )
+  | nodes ( '<XQuery>' ) AS <table_alias> ( <column_alias> )
+
+<for_xml_clause> ::=
+    FOR XML { RAW [ ( '<element_name>' ) ] | AUTO | EXPLICIT | PATH [ ( '<element_name>' ) ] }
+    [ , { XMLDATA | XMLSCHEMA [ ( '<target_namespace>' ) ] } ]
+    [ , ELEMENTS [ { XSINIL | ABSENT } ] ]
+    [ , ROOT [ ( '<root_name>' ) ] ]
+    [ , TYPE ]
+    [ , BINARY BASE64 ]
+
+<openxml_clause> ::=
+    OPENXML ( <idoc> , '<rowpattern>' [ , <flags> ] )
+    [ WITH ( { <schema_declaration> | <table_name> } ) ]
+```
+
+### 13. JSON Support (SQL Server 2016+)
+
+```ebnf
+<json_functions> ::=
+    ISJSON ( <expression> )
+  | JSON_VALUE ( <expression> , '<path>' )
+  | JSON_QUERY ( <expression> [ , '<path>' ] )
+  | JSON_MODIFY ( <expression> , '<path>' , <new_value> )
+  | OPENJSON ( <expression> [ , '<path>' ] ) [ WITH ( <schema_definition> ) ]
+  | JSON_PATH_EXISTS ( <expression> , '<path>' )  /* SQL Server 2022+ */
+
+<for_json_clause> ::=
+    FOR JSON { AUTO | PATH }
+    [ , ROOT [ ( '<root_name>' ) ] ]
+    [ , INCLUDE_NULL_VALUES ]
+    [ , WITHOUT_ARRAY_WRAPPER ]
+
+<json_path> ::= '$' [ <path_element> { <path_element> } ]
+<path_element> ::= '.' <member> | '[' <index> ']' | '.*'
+```
+
+### 14. Window Functions
+
+```ebnf
+<window_function> ::=
+    <window_function_name> ( [ <expression> { , <expression> } ] ) 
+    OVER ( [ <partition_by_clause> ] [ <order_by_clause> ] [ <frame_clause> ] )
+
+<window_function_name> ::=
+    -- Ranking functions
+    ROW_NUMBER | RANK | DENSE_RANK | NTILE
+    -- Aggregate functions
+  | SUM | AVG | MIN | MAX | COUNT | COUNT_BIG 
+  | STDEV | STDEVP | VAR | VARP
+  | CHECKSUM_AGG | GROUPING | GROUPING_ID
+  | STRING_AGG  /* SQL Server 2017+ */
+  | APPROX_COUNT_DISTINCT  /* SQL Server 2019+ */
+    -- Analytic functions
+  | LAG | LEAD | FIRST_VALUE | LAST_VALUE 
+  | PERCENT_RANK | CUME_DIST | PERCENTILE_CONT | PERCENTILE_DISC
+
+<partition_by_clause> ::=
+    PARTITION BY <expression> { , <expression> }
+
+<order_by_clause> ::=
+    ORDER BY <expression> [ { ASC | DESC } ] { , ... }
+
+<frame_clause> ::=
+    { ROWS | RANGE } { <frame_start> | BETWEEN <frame_start> AND <frame_end> }
+
+<frame_start> ::=
+    UNBOUNDED PRECEDING | <unsigned_value> PRECEDING | CURRENT ROW
+
+<frame_end> ::=
+    UNBOUNDED FOLLOWING | <unsigned_value> FOLLOWING | CURRENT ROW
+```
+
+### 15. PIVOT and UNPIVOT
+
+```ebnf
+<pivot_clause> ::=
+    PIVOT ( <aggregate_function> ( <value_column> )
+    FOR <pivot_column> IN ( <column_list> ) ) [ AS ] <alias>
+
+<unpivot_clause> ::=
+    UNPIVOT ( <value_column> FOR <pivot_column> IN ( <column_list> ) ) [ AS ] <alias>
+```
+
+### 16. OUTPUT Clause
+
+```ebnf
+<output_clause> ::=
+    OUTPUT { <output_column> { , <output_column> } }
+    [ INTO { @<table_variable> | <output_table> } [ ( <column_list> ) ] ]
+
+<output_column> ::=
+    { DELETED | INSERTED | <from_table_name> } . { * | <column_name> }
+  | <scalar_expression> [ [ AS ] <column_alias> ]
+  | $action  /* MERGE statement only */
+```
+
+### 17. Service Broker
+
+```ebnf
+<create_message_type> ::=
+    CREATE MESSAGE TYPE <message_type_name>
+    [ AUTHORIZATION <owner_name> ]
+    [ VALIDATION = { NONE | EMPTY | WELL_FORMED_XML 
+                   | VALID_XML WITH SCHEMA COLLECTION <schema_collection> } ]
+
+<create_contract> ::=
+    CREATE CONTRACT <contract_name>
+    [ AUTHORIZATION <owner_name> ]
+    ( <message_type_name> SENT BY { INITIATOR | TARGET | ANY } { , ... } )
+
+<create_queue> ::=
+    CREATE QUEUE [ <schema_name> . ] <queue_name>
+    [ WITH { STATUS = { ON | OFF } 
+           | RETENTION = { ON | OFF }
+           | ACTIVATION ( <activation_options> )
+           | MAX_QUEUE_READERS = <max_readers>
+           | PROCEDURE_NAME = <procedure_name>
+           | EXECUTE AS { SELF | '<user_name>' | OWNER } } { , ... } ]
+    [ ON { <filegroup> | DEFAULT } ]
+
+<send_statement> ::=
+    SEND ON CONVERSATION <conversation_handle>
+    [ MESSAGE TYPE <message_type_name> ]
+    [ ( <message_body_expression> ) ]
+
+<receive_statement> ::=
+    [ WAITFOR ( ] RECEIVE [ TOP ( <n> ) ] <column_specifier> { , ... }
+    FROM <queue_name>
+    [ INTO @<table_variable> ]
+    [ WHERE <where_clause> ] [ ) [ , TIMEOUT <timeout> ] ]
+```
+
+### 18. Full-Text Search
+
+```ebnf
+<contains_predicate> ::=
+    CONTAINS ( { <column_name> | ( <column_list> ) | * } , '<contains_search_condition>' )
+
+<freetext_predicate> ::=
+    FREETEXT ( { <column_name> | ( <column_list> ) | * } , '<freetext_string>' )
+
+<contains_search_condition> ::=
+    { <simple_term>
+    | <prefix_term>
+    | <generation_term>
+    | <proximity_term>
+    | <weighted_term>
+    | { ( <contains_search_condition> ) { AND | & | AND NOT | &! | OR | | } <contains_search_condition> } }
+
+<containstable_function> ::=
+    CONTAINSTABLE ( <table_name> , { <column_name> | ( <column_list> ) | * } , 
+                    '<contains_search_condition>' [ , <top_n_by_rank> ] )
+
+<freetexttable_function> ::=
+    FREETEXTTABLE ( <table_name> , { <column_name> | ( <column_list> ) | * } ,
+                    '<freetext_string>' [ , <top_n_by_rank> ] )
+
+<semantic_functions> ::=
+    SEMANTICKEYPHRASETABLE | SEMANTICSIMILARITYDETAILSTABLE | SEMANTICSIMILARITYTABLE
+```
+
+### 19. Spatial Data (SQL Server 2008+)
+
+```ebnf
+<spatial_methods> ::=
+    -- Geometry methods
+    STArea() | STLength() | STDistance ( <geometry> ) | STIntersects ( <geometry> )
+  | STContains ( <geometry> ) | STWithin ( <geometry> ) | STTouches ( <geometry> )
+  | STOverlaps ( <geometry> ) | STCrosses ( <geometry> ) | STDisjoint ( <geometry> )
+  | STEquals ( <geometry> ) | STIntersection ( <geometry> ) | STUnion ( <geometry> )
+  | STDifference ( <geometry> ) | STSymDifference ( <geometry> ) | STBuffer ( <distance> )
+  | STConvexHull() | STCentroid() | STPointOnSurface() | STExteriorRing()
+  | STInteriorRingN ( <index> ) | STNumInteriorRing() | STPointN ( <index> )
+  | STStartPoint() | STEndPoint() | STX | STY | STZ | STM
+  | STIsValid() | STIsSimple() | STIsEmpty() | STIsClosed() | STIsRing()
+  | STNumPoints() | STNumGeometries() | STGeometryN ( <index> )
+  | STAsText() | STAsBinary() | STGeomFromText ( <wkt> , <srid> )
+  | STGeomFromWKB ( <wkb> , <srid> ) | STSrid
+
+<spatial_aggregates> ::=
+    CollectionAggregate | ConvexHullAggregate | EnvelopeAggregate | UnionAggregate
+```
+
+### 20. Temporal Tables (SQL Server 2016+)
+
+```ebnf
+<temporal_table_clause> ::=
+    PERIOD FOR SYSTEM_TIME ( <start_column> , <end_column> )
+
+<system_versioning_clause> ::=
+    WITH ( SYSTEM_VERSIONING = ON 
+         [ ( HISTORY_TABLE = <schema_name>.<history_table_name> 
+             [ , DATA_CONSISTENCY_CHECK = { ON | OFF } ]
+             [ , HISTORY_RETENTION_PERIOD = { INFINITE | <number> { DAY | DAYS | WEEK | WEEKS 
+                                                                   | MONTH | MONTHS | YEAR | YEARS } } ] ) ] )
+
+<temporal_query_clause> ::=
+    FOR SYSTEM_TIME { AS OF <date_time>
+                    | FROM <start_date_time> TO <end_date_time>
+                    | BETWEEN <start_date_time> AND <end_date_time>
+                    | CONTAINED IN ( <start_date_time> , <end_date_time> )
+                    | ALL }
+```
+
+### 21. Row-Level Security (SQL Server 2016+)
+
+```ebnf
+<create_security_policy> ::=
+    CREATE SECURITY POLICY <policy_name>
+    [ { ADD | ALTER } [ FILTER | BLOCK ] PREDICATE <function_name> ( <column_list> ) 
+      ON <table_name> [ , ... ] ]
+    [ WITH ( STATE = { ON | OFF } 
+           [ , SCHEMABINDING = { ON | OFF } ] ) ]
+
+<security_predicate> ::=
+    { FILTER | BLOCK } PREDICATE <function_name> ( <column_list> ) 
+    ON <table_name> [ AFTER { INSERT | UPDATE } ]
+```
+
+### 22. Dynamic Data Masking (SQL Server 2016+)
+
+```ebnf
+<data_masking> ::=
+    MASKED WITH ( FUNCTION = '<masking_function>' )
+
+<masking_function> ::=
+    'default()' 
+  | 'default(<default_value>)'
+  | 'email()'
+  | 'random(<start>, <end>)'
+  | 'partial(<prefix>, <padding>, <suffix>)'
+  | 'datetime(<format>)'  /* SQL Server 2022+ */
+```
+
+### 23. Graph Tables (SQL Server 2017+)
+
+```ebnf
+<create_graph_table> ::=
+    CREATE TABLE <table_name> ( <column_definition> { , ... } ) AS { NODE | EDGE }
+
+<graph_predicates> ::=
+    MATCH ( <graph_search_pattern> )
+
+<graph_search_pattern> ::=
+    <node_alias> { - ( <edge_alias> ) -> <node_alias> }
+  | <node_alias> { <- ( <edge_alias> ) - <node_alias> }
+  | <graph_search_pattern> { AND | OR } <graph_search_pattern>
+  | ( <graph_search_pattern> )
+
+<graph_functions> ::=
+    NODE_ID_FROM_PARTS ( <object_id> , <graph_id> )  /* SQL Server 2019+ */
+  | OBJECT_ID_FROM_NODE_ID ( <node_id> )  /* SQL Server 2019+ */
+  | GRAPH_ID_FROM_NODE_ID ( <node_id> )  /* SQL Server 2019+ */
+  | EDGE_ID_FROM_PARTS ( <object_id> , <graph_id> )  /* SQL Server 2019+ */
+  | OBJECT_ID_FROM_EDGE_ID ( <edge_id> )  /* SQL Server 2019+ */
+  | GRAPH_ID_FROM_EDGE_ID ( <edge_id> )  /* SQL Server 2019+ */
+
+<shortest_path> ::=
+    SHORTEST_PATH ( <node_alias> { ( - ( <edge_alias> ) -> <node_alias> ) + } )  /* SQL Server 2019+ */
+```
+
+### 24. Machine Learning Services
+
+```ebnf
+<sp_execute_external_script> ::=
+    EXEC sp_execute_external_script
+    @language = N'{ Python | R | Java }'
+    , @script = N'<script>'
+    [ , @input_data_1 = N'<input_query>' ]
+    [ , @input_data_1_name = N'<input_name>' ]
+    [ , @output_data_1_name = N'<output_name>' ]
+    [ , @parallel = { 0 | 1 } ]
+    [ , @params = N'<parameter_definition>' ]
+    [ , <parameter_name> = <value> { , ... } ]
+    [ WITH RESULT SETS ( <result_sets_definition> ) ]
+
+<create_external_language> ::=
+    CREATE EXTERNAL LANGUAGE <language_name>
+    [ AUTHORIZATION <owner_name> ]
+    FROM { <file_spec> { , <file_spec> } | <content_spec> }  /* SQL Server 2019+ */
+
+<predict_function> ::=
+    PREDICT ( MODEL = @<model_variable> , DATA = <table_source> )  /* SQL Server 2017+ */
+    [ WITH ( <runtime_parameter> = <value> { , ... } ) ]
+```
+
+### 25. Query Store
+
+```ebnf
+<alter_database_query_store> ::=
+    ALTER DATABASE <database_name>
+    SET QUERY_STORE { = { ON | OFF } 
+                    | ( <query_store_option> { , ... } ) 
+                    | CLEAR [ ALL ] }
+
+<query_store_option> ::=
+    OPERATION_MODE = { READ_ONLY | READ_WRITE }
+  | CLEANUP_POLICY = ( STALE_QUERY_THRESHOLD_DAYS = <number> )
+  | DATA_FLUSH_INTERVAL_SECONDS = <number>
+  | INTERVAL_LENGTH_MINUTES = <number>
+  | MAX_STORAGE_SIZE_MB = <number>
+  | QUERY_CAPTURE_MODE = { ALL | AUTO | NONE | CUSTOM }  /* CUSTOM: SQL Server 2019+ */
+  | QUERY_CAPTURE_POLICY = ( <capture_policy_option> { , ... } )  /* SQL Server 2019+ */
+  | SIZE_BASED_CLEANUP_MODE = { AUTO | OFF }
+  | MAX_PLANS_PER_QUERY = <number>
+  | WAIT_STATS_CAPTURE_MODE = { ON | OFF }  /* SQL Server 2017+ */
+```
+
+### 26. PolyBase (SQL Server 2016+)
+
+```ebnf
+<create_external_data_source> ::=
+    CREATE EXTERNAL DATA SOURCE <data_source_name>
+    WITH ( TYPE = { HADOOP | SHARD_MAP_MANAGER | RDBMS | BLOB_STORAGE }
+         , LOCATION = '<location>'
+         [ , RESOURCE_MANAGER_LOCATION = '<resource_manager>' ]
+         [ , CREDENTIAL = <credential_name> ]
+         [ , DATABASE_NAME = '<database>' ]
+         [ , SHARD_MAP_NAME = '<shard_map>' ] )
+
+<create_external_table> ::=
+    CREATE EXTERNAL TABLE [ <schema_name> . ] <table_name>
+    ( <column_definition> { , ... } )
+    WITH ( LOCATION = '<folder_or_filepath>'
+         , DATA_SOURCE = <data_source_name>
+         , FILE_FORMAT = <file_format_name>
+         [ , REJECT_TYPE = { VALUE | PERCENTAGE } ]
+         [ , REJECT_VALUE = <value> ]
+         [ , REJECT_SAMPLE_VALUE = <value> ] )
+
+<create_external_file_format> ::=
+    CREATE EXTERNAL FILE FORMAT <file_format_name>
+    WITH ( FORMAT_TYPE = { PARQUET | ORC | RCFILE | DELIMITEDTEXT | JSON | DELTA }  /* DELTA: SQL Server 2022+ */
+         [ , <format_options> ] )
+```
+
+### 27. Intelligent Query Processing (SQL Server 2017+)
+
+```ebnf
+<database_scoped_configuration> ::=
+    ALTER DATABASE SCOPED CONFIGURATION 
+    { SET <option_name> = { ON | OFF | PRIMARY }
+    | CLEAR PROCEDURE_CACHE 
+    | FOR SECONDARY SET <option_name> = { ON | OFF | PRIMARY } }
+
+<intelligent_qp_options> ::=
+    BATCH_MODE_ADAPTIVE_JOINS  /* SQL Server 2017+ */
+  | BATCH_MODE_MEMORY_GRANT_FEEDBACK  /* SQL Server 2017+ */
+  | BATCH_MODE_ON_ROWSTORE  /* SQL Server 2019+ */
+  | DEFERRED_COMPILATION_TV  /* SQL Server 2019+ */
+  | INTERLEAVED_EXECUTION_TVF  /* SQL Server 2017+ */
+  | LAST_QUERY_PLAN_STATS  /* SQL Server 2019+ */
+  | LIGHTWEIGHT_QUERY_PROFILING  /* SQL Server 2019+ */
+  | ROW_MODE_MEMORY_GRANT_FEEDBACK  /* SQL Server 2019+ */
+  | SCALAR_UDF_INLINING  /* SQL Server 2019+ */
+  | T_MIN_MAX_CLUSTERCOLUMNSTORE_SKIP  /* SQL Server 2019+ */
+  | TSQL_SCALAR_UDF_INLINING  /* SQL Server 2019+ */
+  | APPROX_PERCENTILE_CONT  /* SQL Server 2022+ */
+  | APPROX_PERCENTILE_DISC  /* SQL Server 2022+ */
+  | OPTIMIZED_PLAN_FORCING  /* SQL Server 2022+ */
+  | PARAMETER_SENSITIVE_PLAN_OPTIMIZATION  /* SQL Server 2022+ */
+```
+
+### 28. Ledger Tables (SQL Server 2022+)
+
+```ebnf
+<create_ledger_table> ::=
+    CREATE TABLE <table_name> ( <column_definition> { , ... } )
+    WITH ( LEDGER = ON [ ( <ledger_option> { , ... } ) ] )
+
+<ledger_option> ::=
+    LEDGER_VIEW = <schema_name>.<ledger_view_name> 
+        [ ( TRANSACTION_ID_COLUMN_NAME = <column_name>
+          , SEQUENCE_NUMBER_COLUMN_NAME = <column_name>  
+          , OPERATION_TYPE_COLUMN_NAME = <column_name>
+          , OPERATION_TYPE_DESC_COLUMN_NAME = <column_name> ) ]
+  | APPEND_ONLY = { ON | OFF }
+
+<ledger_verification> ::=
+    sp_verify_database_ledger [ @table_name = '<table_name>' ]
+                             [ , @verification_option = '<option>' ]
+
+<generate_ledger_digest> ::=
+    EXEC sp_generate_database_ledger_digest
+```
+
+### 29. Query Hints
+
+```ebnf
+<query_hint> ::=
+    { FAST <number>
+    | FORCE ORDER
+    | { LOOP | MERGE | HASH } JOIN
+    | EXPAND VIEWS
+    | PARAMETERIZATION { SIMPLE | FORCED }
+    | RECOMPILE
+    | ROBUST PLAN
+    | KEEP PLAN
+    | KEEPFIXED PLAN
+    | MAXDOP <number>
+    | MAXRECURSION <number>
+    | OPTIMIZE FOR { @<variable> = <literal> } { , ... }
+    | OPTIMIZE FOR UNKNOWN
+    | NO_PERFORMANCE_SPOOL
+    | USE HINT ( '<hint_string>' { , ... } )  /* SQL Server 2016 SP1+ */
+    | USE PLAN N'<xml_plan>'
+    | TABLE HINT ( <table_alias> , <table_hint> { , ... } )
+    | QUERYTRACEON <trace_flag>
+    | ASSUME_JOIN_PREDICATE_DEPENDS_ON_FILTERS  /* SQL Server 2019+ */
+    | ASSUME_MIN_SELECTIVITY_FOR_FILTER_ESTIMATES  /* SQL Server 2019+ */
+    | DISABLE_BATCH_MODE_ADAPTIVE_JOINS  /* SQL Server 2017+ */
+    | DISABLE_BATCH_MODE_MEMORY_GRANT_FEEDBACK  /* SQL Server 2017+ */
+    | DISABLE_DEFERRED_COMPILATION_TV  /* SQL Server 2019+ */
+    | DISABLE_INTERLEAVED_EXECUTION_TVF  /* SQL Server 2017+ */
+    | DISABLE_OPTIMIZED_NESTED_LOOP  /* SQL Server 2019+ */
+    | DISABLE_OPTIMIZER_ROWGOAL  /* SQL Server 2016+ */
+    | DISABLE_PARAMETER_SNIFFING
+    | DISABLE_ROW_MODE_MEMORY_GRANT_FEEDBACK  /* SQL Server 2019+ */
+    | DISABLE_TSQL_SCALAR_UDF_INLINING  /* SQL Server 2019+ */
+    | DISALLOW_BATCH_MODE  /* SQL Server 2019+ */
+    | ENABLE_HIST_AMENDMENT_FOR_ASC_KEYS  /* SQL Server 2019+ */
+    | ENABLE_QUERY_OPTIMIZER_HOTFIXES
+    | FORCE_DEFAULT_CARDINALITY_ESTIMATION  /* SQL Server 2016+ */
+    | FORCE_LEGACY_CARDINALITY_ESTIMATION  /* SQL Server 2016+ */
+    | QUERY_PLAN_PROFILE  /* SQL Server 2019+ */ }
+```
+
+### 30. System Functions and Variables
+
+```ebnf
+<system_function> ::=
+    -- Metadata functions
+    @@DBTS | @@LANGID | @@LANGUAGE | @@LOCK_TIMEOUT | @@MAX_CONNECTIONS
+  | @@MAX_PRECISION | @@NESTLEVEL | @@OPTIONS | @@REMSERVER | @@SERVERNAME
+  | @@SERVICENAME | @@SPID | @@TEXTSIZE | @@VERSION
+  | APP_NAME() | APPLOCK_MODE() | APPLOCK_TEST() | ASSEMBLYPROPERTY()
+  | COL_LENGTH() | COL_NAME() | COLUMNPROPERTY() | DATABASE_PRINCIPAL_ID()
+  | DATABASEPROPERTYEX() | DB_ID() | DB_NAME() | FILE_ID() | FILE_IDEX()
+  | FILE_NAME() | FILEGROUP_ID() | FILEGROUP_NAME() | FILEGROUPPROPERTY()
+  | FILEPROPERTY() | FILEPROPERTYEX() | FULLTEXTCATALOGPROPERTY()
+  | FULLTEXTSERVICEPROPERTY() | INDEX_COL() | INDEXKEY_PROPERTY()
+  | INDEXPROPERTY() | IS_MEMBER() | IS_ROLEMEMBER() | IS_SRVROLEMEMBER()
+  | OBJECT_DEFINITION() | OBJECT_ID() | OBJECT_NAME() | OBJECT_SCHEMA_NAME()
+  | OBJECTPROPERTY() | OBJECTPROPERTYEX() | ORIGINAL_DB_NAME()
+  | PARSENAME() | PERMISSIONS() | PWDCOMPARE() | PWDENCRYPT()
+  | QUOTENAME() | SCHEMA_ID() | SCHEMA_NAME() | SCOPE_IDENTITY()
+  | SERVERPROPERTY() | SESSION_USER | SESSIONPROPERTY() | STATS_DATE()
+  | SUSER_ID() | SUSER_NAME() | SUSER_SID() | SUSER_SNAME()
+  | SYSTEM_USER | TYPE_ID() | TYPE_NAME() | TYPEPROPERTY()
+  | USER_ID() | USER_NAME()
+    -- Security functions
+  | CERTENCODED() | CERTPRIVATEKEY() | CURRENT_USER | HAS_PERMS_BY_NAME()
+  | IS_OBJECTSIGNED() | IS_ROLEMEMBER() | IS_SRVROLEMEMBER()
+  | LOGINPROPERTY() | ORIGINAL_LOGIN() | PERMISSIONS()
+  | SESSION_USER | SUSER_ID() | SUSER_NAME() | SUSER_SID()
+  | SUSER_SNAME() | SYSTEM_USER | USER_ID() | USER_NAME()
+    -- System statistical functions
+  | @@CONNECTIONS | @@CPU_BUSY | @@IDLE | @@IO_BUSY | @@PACK_RECEIVED
+  | @@PACK_SENT | @@PACKET_ERRORS | @@TIMETICKS | @@TOTAL_ERRORS
+  | @@TOTAL_READ | @@TOTAL_WRITE | FN_VIRTUALFILESTATS()
+    -- Configuration functions
+  | @@DATEFIRST | @@DBTS | @@LANGID | @@LANGUAGE | @@LOCK_TIMEOUT
+  | @@MAX_CONNECTIONS | @@MAX_PRECISION | @@NESTLEVEL | @@OPTIONS
+  | @@REMSERVER | @@SERVERNAME | @@SERVICENAME | @@SPID
+  | @@TEXTSIZE | @@VERSION
+```
+
+### 31. Operators
+
+```ebnf
+<operator> ::=
+    -- Arithmetic
+    + | - | * | / | %
+
+    -- Bitwise
+    & | | | ^ | ~
+
+    -- Comparison
+    = | > | < | >= | <= | <> | != | !< | !>
+
+    -- Logical
+    ALL | AND | ANY | BETWEEN | EXISTS | IN | LIKE | NOT | OR | SOME
+
+    -- String concatenation
+    +
+
+    -- Compound assignment
+    += | -= | *= | /= | %= | &= | ^= | |=
+
+    -- Unary
+    + | - | ~
+
+    -- Scope resolution
+    ::
+```
+
+### 32. Special Constructs
+
+```ebnf
+<case_expression> ::=
+    CASE { <input_expression> 
+           WHEN <when_expression> THEN <result_expression> { ... }
+         | WHEN <boolean_expression> THEN <result_expression> { ... } }
+    [ ELSE <else_result_expression> ] END
+
+<iif_function> ::=
+    IIF ( <boolean_expression> , <true_value> , <false_value> )  /* SQL Server 2012+ */
+
+<choose_function> ::=
+    CHOOSE ( <index> , <value1> , <value2> { , ... } )  /* SQL Server 2012+ */
+
+<nullif_expression> ::=
+    NULLIF ( <expression> , <expression> )
+
+<coalesce_expression> ::=
+    COALESCE ( <expression> { , <expression> } )
+
+<format_function> ::=
+    FORMAT ( <value> , '<format>' [ , '<culture>' ] )  /* SQL Server 2012+ */
+
+<concat_function> ::=
+    CONCAT ( <string_value1> , <string_value2> { , ... } )  /* SQL Server 2012+ */
+  | CONCAT_WS ( '<separator>' , <string_value1> , <string_value2> { , ... } )  /* SQL Server 2017+ */
+
+<string_split_function> ::=
+    STRING_SPLIT ( <string> , '<separator>' [ , <enable_ordinal> ] )  /* SQL Server 2016+, ordinal: 2022+ */
+
+<string_agg_function> ::=
+    STRING_AGG ( <expression> , '<separator>' ) [ WITHIN GROUP ( ORDER BY <order_list> ) ]  /* SQL Server 2017+ */
+
+<trim_function> ::=
+    TRIM ( [ [ { LEADING | TRAILING | BOTH } ] [ <characters> ] FROM ] <string> )  /* SQL Server 2017+ */
+
+<translate_function> ::=
+    TRANSLATE ( <input_string> , '<characters>' , '<translations>' )  /* SQL Server 2017+ */
+
+<approx_count_distinct> ::=
+    APPROX_COUNT_DISTINCT ( <expression> )  /* SQL Server 2019+ */
+
+<datetrunc_function> ::=
+    DATETRUNC ( <datepart> , <date> )  /* SQL Server 2022+ */
+
+<date_bucket_function> ::=
+    DATE_BUCKET ( <datepart> , <number> , <date> [ , <origin> ] )  /* SQL Server 2022+ */
+
+<greatest_least_functions> ::=
+    GREATEST ( <expression> { , <expression> } )  /* SQL Server 2022+ */
+  | LEAST ( <expression> { , <expression> } )  /* SQL Server 2022+ */
+
+<bit_manipulation_functions> ::=
+    BIT_COUNT ( <expression> )  /* SQL Server 2022+ */
+  | GET_BIT ( <expression> , <bit_position> )  /* SQL Server 2022+ */
+  | SET_BIT ( <expression> , <bit_position> [ , <bit_value> ] )  /* SQL Server 2022+ */
+  | LEFT_SHIFT ( <expression> , <shift_count> )  /* SQL Server 2022+ */
+  | RIGHT_SHIFT ( <expression> , <shift_count> )  /* SQL Server 2022+ */
+```
+
+## Usage Notes
+
+1. **Version Compatibility**: Features marked with version comments require specific SQL Server versions
+2. **Case Sensitivity**: Default collation determines identifier case sensitivity
+3. **Identifier Delimiters**: Use square brackets `[ ]` or double quotes `" "` (with QUOTED_IDENTIFIER ON)
+4. **Statement Terminators**: Semicolon `;` is optional but recommended
+5. **Batch Separators**: `GO` is used by client tools, not part of T-SQL
+6. **Comments**: 
+   - Single line: `--`
+   - Multi-line: `/* ... */`
+7. **String Literals**: Use single quotes `'`, double with `''` for embedded quotes
+8. **Unicode Strings**: Prefix with `N`, e.g., `N'Unicode string'`
+9. **Binary Literals**: Use `0x` prefix, e.g., `0xDEADBEEF`
+10. **Money Literals**: Use currency symbol, e.g., `$123.45`
+11. **Date/Time Literals**: Various formats supported, ISO 8601 recommended
+12. **NULL Handling**: Three-valued logic (TRUE, FALSE, UNKNOWN)
+13. **Collations**: Affect string comparisons and sorting
+14. **Schemas**: Default is `dbo`, always qualify objects in production code
+15. **Deprecated Features**: Avoid TEXT, NTEXT, IMAGE; use (N)VARCHAR(MAX), VARBINARY(MAX)
+
+This comprehensive grammar covers T-SQL from SQL Server 2008 through SQL Server 2022, providing a complete foundation for implementing a T-SQL parser.


### PR DESCRIPTION
Add comprehensive BNF/EBNF grammar reports for PostgreSQL, MySQL/MariaDB, and Firebird SQL dialects to provide detailed specifications for AI-driven parser re-implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f645fe71-3c65-4772-b3dc-fd5b9bc5b785">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f645fe71-3c65-4772-b3dc-fd5b9bc5b785">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

